### PR TITLE
Use consistent type size_t for node_count() in C++ bindings

### DIFF
--- a/bindings/cpp/include/oxidd/bcdd.hpp
+++ b/bindings/cpp/include/oxidd/bcdd.hpp
@@ -509,7 +509,7 @@ public:
   /// Locking behavior: acquires a shared manager lock.
   ///
   /// @returns  Node count including the terminal node
-  [[nodiscard]] size_t node_count() const noexcept {
+  [[nodiscard]] std::size_t node_count() const noexcept {
     assert(_func._p);
     return capi::oxidd_bcdd_node_count(_func);
   }

--- a/bindings/cpp/include/oxidd/bdd.hpp
+++ b/bindings/cpp/include/oxidd/bdd.hpp
@@ -507,7 +507,7 @@ public:
   /// Locking behavior: acquires a shared manager lock.
   ///
   /// @returns  Node count including the two terminal nodes
-  [[nodiscard]] uint64_t node_count() const noexcept {
+  [[nodiscard]] std::size_t node_count() const noexcept {
     assert(_func._p);
     return capi::oxidd_bdd_node_count(_func);
   }

--- a/bindings/cpp/include/oxidd/concepts.hpp
+++ b/bindings/cpp/include/oxidd/concepts.hpp
@@ -5,6 +5,7 @@
 #if __cplusplus >= 202002L
 
 #include <concepts>
+#include <cstddef>
 #include <cstdlib>
 #include <functional>
 #include <utility>

--- a/bindings/cpp/include/oxidd/zbdd.hpp
+++ b/bindings/cpp/include/oxidd/zbdd.hpp
@@ -545,7 +545,7 @@ public:
   /// Locking behavior: acquires a shared manager lock.
   ///
   /// @returns  Node count including the two terminal nodes
-  [[nodiscard]] uint64_t node_count() const noexcept {
+  [[nodiscard]] std::size_t node_count() const noexcept {
     assert(_func._p);
     return capi::oxidd_zbdd_node_count(_func);
   }


### PR DESCRIPTION
While trying to compile the C++ bindings, I had some compilation errors because `node_count()` different types.

This PR consistently uses `uint64_t` as default for `node_count()` because it seemed more widely used. One could of course also use `size_t` instead.