### PR TITLE
Fix CMake cannot find 'oxidd_ffi' target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,12 +67,12 @@ corrosion_import_crate(
     PROFILE ${OXIDD_CARGO_PROFILE}
     CRATES oxidd-ffi
     CRATE_TYPES cdylib staticlib)
-add_dependencies(oxidd_ffi oxidd-capi-header)
-target_include_directories(oxidd_ffi INTERFACE
+add_dependencies(oxidd-ffi oxidd-capi-header)
+target_include_directories(oxidd-ffi INTERFACE
     ${oxidd_capi_include}
     ${PROJECT_SOURCE_DIR}/bindings/cpp/include)
 
-add_library(oxidd ALIAS oxidd_ffi)
+add_library(oxidd ALIAS oxidd-ffi)
 
 add_subdirectory(bindings/cpp/tests EXCLUDE_FROM_ALL)
 


### PR DESCRIPTION
With 70d6d82 , the 'oxidd-ffi' target was treated as if renamed  to 'oxidd_ffi' even though 'corrosion_import_crate' still creates said target with the previous name.