### PR TITLE
Implemented optimised apply_quant function for BDDs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Test
       run: pytest
     - name: Sphinx
-      run: sphinx-build -W bindings/python/doc target/python/doc
+      run: sphinx-build bindings/python/doc target/python/doc
     - name: Deploy Docs
       if: ${{ github.repository == 'OxiDD/oxidd' && github.ref == 'refs/heads/main' }}
       working-directory: target/python/doc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,9 @@ find_program(CBINDGEN_EXECUTABLE
 # Generate oxidd/capi.h using cbindgen
 set(oxidd_capi_include ${PROJECT_BINARY_DIR}/include)
 set(oxidd_capi_h ${oxidd_capi_include}/oxidd/capi.h)
-file(GLOB_RECURSE oxidd_ffi_sources CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/crates/oxidd-ffi/*.rs)
+file(GLOB_RECURSE oxidd_ffi_sources CONFIGURE_DEPENDS
+    ${PROJECT_SOURCE_DIR}/crates/oxidd-core/*.rs
+    ${PROJECT_SOURCE_DIR}/crates/oxidd-ffi/*.rs)
 add_custom_command(
     OUTPUT ${oxidd_capi_h}
     COMMAND ${CBINDGEN_EXECUTABLE}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,18 +797,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -864,9 +864,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.68"
+version = "2.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "201fcda3845c23e8212cd466bfebf0bd20694490fc0356ae8e428e0824a915a6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -949,9 +949,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a5f13f11071020bb12de7a16b925d2d58636175c20c11dc5f96cb64bb6c9b3"
+checksum = "5b1e5645f2ee8025c2f1d75e1138f2dd034d74e6ba54620f3c569ba2a2a1ea06"
 dependencies = [
  "glob",
  "serde",

--- a/bindings/cpp/include/oxidd/bcdd.hpp
+++ b/bindings/cpp/include/oxidd/bcdd.hpp
@@ -540,6 +540,48 @@ public:
     return capi::oxidd_bcdd_unique(_func, vars._func);
   }
 
+  /// Combined application of `op` and `forall()`
+  ///
+  /// Locking behavior: acquires the manager's lock for shared access.
+  ///
+  /// @returns  The BCDD function `∀ vars. this <op> rhs` (may be invalid if the
+  ///           operation runs out of memory)
+  [[nodiscard]] bcdd_function
+  apply_forall(const util::boolean_operator op, const bcdd_function &rhs,
+               const bcdd_function &vars) const noexcept {
+    return capi::oxidd_bcdd_apply_forall(
+        static_cast<capi::oxidd_boolean_operator>(op), _func, rhs._func,
+        vars._func);
+  }
+
+  /// Combined application of `op` and `exist()`
+  ///
+  /// Locking behavior: acquires the manager's lock for shared access.
+  ///
+  /// @returns  The BCDD function `∃ vars. this <op> rhs` (may be invalid if the
+  ///           operation runs out of memory)
+  [[nodiscard]] bcdd_function
+  apply_exist(const util::boolean_operator op, const bcdd_function &rhs,
+              const bcdd_function &vars) const noexcept {
+    return capi::oxidd_bcdd_apply_exist(
+        static_cast<capi::oxidd_boolean_operator>(op), _func, rhs._func,
+        vars._func);
+  }
+
+  /// Combined application of `op` and `unique()`
+  ///
+  /// Locking behavior: acquires the manager's lock for shared access.
+  ///
+  /// @returns  The BCDD function `∃! vars. this <op> rhs` (may be invalid if
+  ///           the operation runs out of memory)
+  [[nodiscard]] bcdd_function
+  apply_unique(const util::boolean_operator op, const bcdd_function &rhs,
+               const bcdd_function &vars) const noexcept {
+    return capi::oxidd_bcdd_apply_unique(
+        static_cast<capi::oxidd_boolean_operator>(op), _func, rhs._func,
+        vars._func);
+  }
+
   /// @}
   /// @name Query Operations on BCDDs
   /// @{

--- a/bindings/cpp/include/oxidd/bdd.hpp
+++ b/bindings/cpp/include/oxidd/bdd.hpp
@@ -544,6 +544,48 @@ public:
     return capi::oxidd_bdd_unique(_func, vars._func);
   }
 
+  /// Combined application of `op` and `forall()`
+  ///
+  /// Locking behavior: acquires the manager's lock for shared access.
+  ///
+  /// @returns  The BDD function `∀ vars. this <op> rhs` (may be invalid if the
+  ///           operation runs out of memory)
+  [[nodiscard]] bdd_function
+  apply_forall(const util::boolean_operator op, const bdd_function &rhs,
+               const bdd_function &vars) const noexcept {
+    return capi::oxidd_bdd_apply_forall(
+        static_cast<capi::oxidd_boolean_operator>(op), _func, rhs._func,
+        vars._func);
+  }
+
+  /// Combined application of `op` and `exist()`
+  ///
+  /// Locking behavior: acquires the manager's lock for shared access.
+  ///
+  /// @returns  The BDD function `∃ vars. this <op> rhs` (may be invalid if the
+  ///           operation runs out of memory)
+  [[nodiscard]] bdd_function
+  apply_exist(const util::boolean_operator op, const bdd_function &rhs,
+              const bdd_function &vars) const noexcept {
+    return capi::oxidd_bdd_apply_exist(
+        static_cast<capi::oxidd_boolean_operator>(op), _func, rhs._func,
+        vars._func);
+  }
+
+  /// Combined application of `op` and `unique()`
+  ///
+  /// Locking behavior: acquires the manager's lock for shared access.
+  ///
+  /// @returns  The BDD function `∃! vars. this <op> rhs` (may be invalid if the
+  ///           operation runs out of memory)
+  [[nodiscard]] bdd_function
+  apply_unique(const util::boolean_operator op, const bdd_function &rhs,
+               const bdd_function &vars) const noexcept {
+    return capi::oxidd_bdd_apply_unique(
+        static_cast<capi::oxidd_boolean_operator>(op), _func, rhs._func,
+        vars._func);
+  }
+
   /// @}
   /// @name Query Operations on BDDs
   /// @{

--- a/bindings/cpp/include/oxidd/util.hpp
+++ b/bindings/cpp/include/oxidd/util.hpp
@@ -42,6 +42,28 @@ enum class opt_bool : int8_t {
   // NOLINTEND(readability-identifier-naming)
 };
 
+/// Binary operator on Boolean functions
+enum class boolean_operator : uint8_t {
+  // NOLINTBEGIN(readability-identifier-naming)
+  /// Conjunction `lhs ∧ rhs`
+  AND = capi::OXIDD_BOOLEAN_OPERATOR_AND,
+  /// Disjunction `lhs ∨ rhs`
+  OR = capi::OXIDD_BOOLEAN_OPERATOR_OR,
+  /// Exclusive disjunction `lhs ⊕ rhs`
+  XOR = capi::OXIDD_BOOLEAN_OPERATOR_XOR,
+  /// Equivalence `lhs ↔ rhs`
+  EQUIV = capi::OXIDD_BOOLEAN_OPERATOR_EQUIV,
+  /// Negated conjunction `lhs ⊼ rhs`
+  NAND = capi::OXIDD_BOOLEAN_OPERATOR_NAND,
+  /// Negated disjunction `lhs ⊽ rhs`
+  NOR = capi::OXIDD_BOOLEAN_OPERATOR_NOR,
+  /// Implication `lhs → rhs`
+  IMP = capi::OXIDD_BOOLEAN_OPERATOR_IMP,
+  /// Strict implication `lhs < rhs`
+  IMP_STRICT = capi::OXIDD_BOOLEAN_OPERATOR_IMP_STRICT,
+  // NOLINTEND(readability-identifier-naming)
+};
+
 /// View into a contiguous sequence, roughly equivalent to Rust's `&[T]` type
 ///
 /// This type is trivially copyable and should be passed by value.

--- a/bindings/python/build/ffi.py
+++ b/bindings/python/build/ffi.py
@@ -152,10 +152,12 @@ def read_cdefs(header: Path) -> str:
             line = next(lines, None)
             if line is None:
                 break
-            if not line:
+            if all(c == "\n" or c == "\r" for c in line):
                 continue
             if line[0] == "#":
-                if line.startswith("#if"):
+                if line.startswith("#if") and not line.startswith(
+                    "#ifndef __cplusplus"
+                ):
                     while True:
                         line = next(lines, None)
                         if line is None:

--- a/bindings/python/oxidd/__init__.py
+++ b/bindings/python/oxidd/__init__.py
@@ -5,7 +5,7 @@ A concurrent decision diagram library.
 
 import importlib.metadata
 
-__all__ = ["bcdd", "bdd", "protocols", "zbdd"]
+__all__ = ["bcdd", "bdd", "protocols", "util", "zbdd"]
 __version__ = importlib.metadata.version("oxidd")
 
-from . import bcdd, bdd, protocols, zbdd
+from . import bcdd, bdd, protocols, util, zbdd

--- a/bindings/python/oxidd/bcdd.py
+++ b/bindings/python/oxidd/bcdd.py
@@ -15,7 +15,7 @@ from . import protocols, util
 class BCDDManager(protocols.BooleanFunctionManager["BCDDFunction"]):
     """Manager for binary decision diagrams with complement edges"""
 
-    _mgr: ...  #: Wrapped FFI object
+    _mgr: ...  #: Wrapped FFI object (``oxidd_bcdd_manager_t``)
 
     def __init__(self, inner_node_capacity: int, apply_cache_size: int, threads: int):
         """Create a new manager
@@ -96,7 +96,7 @@ class BCDDFunction(
     they run out of memory.
     """
 
-    _func: ...  #: Wrapped FFI object
+    _func: ...  #: Wrapped FFI object (``oxidd_bcdd_t``)
 
     def __init__(self, _: Never):
         """Private constructor

--- a/bindings/python/oxidd/bcdd.py
+++ b/bindings/python/oxidd/bcdd.py
@@ -292,6 +292,41 @@ class BCDDFunction(
         return self.__class__._from_raw(_lib.oxidd_bcdd_unique(self._func, vars._func))
 
     @override
+    def apply_forall(self, op: util.BooleanOperator, rhs: Self, vars: Self):
+        if not isinstance(op, util.BooleanOperator):
+            # If op were an arbitrary integer that is not part of the enum,
+            # this would lead to undefined behavior
+            raise ValueError("`op` must be a BooleanOperator")
+        assert (
+            self._func._p == rhs._func._p == vars._func._p
+        ), "`self`, `rhs`, and `vars` must belong to the same manager"
+        return self.__class__._from_raw(
+            _lib.oxidd_bcdd_apply_forall(op, self._func, rhs._func, vars._func)
+        )
+
+    @override
+    def apply_exist(self, op: util.BooleanOperator, rhs: Self, vars: Self):
+        if not isinstance(op, util.BooleanOperator):
+            raise ValueError("`op` must be a BooleanOperator")
+        assert (
+            self._func._p == rhs._func._p == vars._func._p
+        ), "`self`, `rhs`, and `vars` must belong to the same manager"
+        return self.__class__._from_raw(
+            _lib.oxidd_bcdd_apply_exist(op, self._func, rhs._func, vars._func)
+        )
+
+    @override
+    def apply_unique(self, op: util.BooleanOperator, rhs: Self, vars: Self):
+        if not isinstance(op, util.BooleanOperator):
+            raise ValueError("`op` must be a BooleanOperator")
+        assert (
+            self._func._p == rhs._func._p == vars._func._p
+        ), "`self`, `rhs`, and `vars` must belong to the same manager"
+        return self.__class__._from_raw(
+            _lib.oxidd_bcdd_apply_unique(op, self._func, rhs._func, vars._func)
+        )
+
+    @override
     def node_count(self) -> int:
         return int(_lib.oxidd_bcdd_node_count(self._func))
 

--- a/bindings/python/oxidd/bdd.py
+++ b/bindings/python/oxidd/bdd.py
@@ -15,7 +15,7 @@ from . import protocols, util
 class BDDManager(protocols.BooleanFunctionManager["BDDFunction"]):
     """Manager for binary decision diagrams (without complement edges)"""
 
-    _mgr: ...  #: Wrapped FFI object
+    _mgr: ...  #: Wrapped FFI object (``oxidd_bdd_manager_t``)
 
     def __init__(self, inner_node_capacity: int, apply_cache_size: int, threads: int):
         """Create a new manager
@@ -95,7 +95,7 @@ class BDDFunction(
     run out of memory.
     """
 
-    _func: ...  #: Wrapped FFI object
+    _func: ...  #: Wrapped FFI object (``oxidd_bdd_t``)
 
     def __init__(self, _: Never):
         """Private constructor

--- a/bindings/python/oxidd/bdd.py
+++ b/bindings/python/oxidd/bdd.py
@@ -290,6 +290,41 @@ class BDDFunction(
         return self.__class__._from_raw(_lib.oxidd_bdd_unique(self._func, vars._func))
 
     @override
+    def apply_forall(self, op: util.BooleanOperator, rhs: Self, vars: Self):
+        if not isinstance(op, util.BooleanOperator):
+            # If op were an arbitrary integer that is not part of the enum,
+            # this would lead to undefined behavior
+            raise ValueError("`op` must be a BooleanOperator")
+        assert (
+            self._func._p == rhs._func._p == vars._func._p
+        ), "`self`, `rhs`, and `vars` must belong to the same manager"
+        return self.__class__._from_raw(
+            _lib.oxidd_bdd_apply_forall(op, self._func, rhs._func, vars._func)
+        )
+
+    @override
+    def apply_exist(self, op: util.BooleanOperator, rhs: Self, vars: Self):
+        if not isinstance(op, util.BooleanOperator):
+            raise ValueError("`op` must be a BooleanOperator")
+        assert (
+            self._func._p == rhs._func._p == vars._func._p
+        ), "`self`, `rhs`, and `vars` must belong to the same manager"
+        return self.__class__._from_raw(
+            _lib.oxidd_bdd_apply_exist(op, self._func, rhs._func, vars._func)
+        )
+
+    @override
+    def apply_unique(self, op: util.BooleanOperator, rhs: Self, vars: Self):
+        if not isinstance(op, util.BooleanOperator):
+            raise ValueError("`op` must be a BooleanOperator")
+        assert (
+            self._func._p == rhs._func._p == vars._func._p
+        ), "`self`, `rhs`, and `vars` must belong to the same manager"
+        return self.__class__._from_raw(
+            _lib.oxidd_bdd_apply_unique(op, self._func, rhs._func, vars._func)
+        )
+
+    @override
     def node_count(self) -> int:
         return int(_lib.oxidd_bdd_node_count(self._func))
 

--- a/bindings/python/oxidd/protocols.py
+++ b/bindings/python/oxidd/protocols.py
@@ -18,7 +18,7 @@ from typing import Generic, Optional, Protocol, TypeVar
 
 from typing_extensions import Self
 
-from .util import Assignment
+from .util import Assignment, BooleanOperator
 
 
 class Function(Protocol):
@@ -349,6 +349,36 @@ class BooleanFunctionQuant(BooleanFunction, Protocol):
 
         Acquires the manager's lock for shared access.
         """  # noqa: E501
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply_forall(self, op: BooleanOperator, rhs: Self, vars: Self) -> Self:
+        """Combined application of ``op`` and :meth:`forall()`:
+        ``∀ vars. self <op> rhs``
+
+        ``self``, ``rhs``, and ``vars`` must belong to the same manager.
+
+        Acquires the manager's lock for shared access."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply_exist(self, op: BooleanOperator, rhs: Self, vars: Self) -> Self:
+        """Combined application of ``op`` and :meth:`exist()`:
+        ``∃ vars. self <op> rhs``
+
+        ``self``, ``rhs``, and ``vars`` must belong to the same manager.
+
+        Acquires the manager's lock for shared access."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply_unique(self, op: BooleanOperator, rhs: Self, vars: Self) -> Self:
+        """Combined application of ``op`` and :meth:`unique()`:
+        ``∃! vars. self <op> rhs``
+
+        ``self``, ``rhs``, and ``vars`` must belong to the same manager.
+
+        Acquires the manager's lock for shared access."""
         raise NotImplementedError
 
 

--- a/bindings/python/oxidd/tests/test_boolean_function.py
+++ b/bindings/python/oxidd/tests/test_boolean_function.py
@@ -292,6 +292,7 @@ def test_bdd_all_boolean_functions_2vars_t1():
     vars = [mgr.new_var() for _ in range(2)]
     test = AllBooleanFunctionsQuantSubst(mgr, vars, vars)
     test.basic()
+    test.subst()
     test.quant()
 
 
@@ -300,6 +301,7 @@ def test_bcdd_all_boolean_functions_2vars_t1():
     vars = [mgr.new_var() for _ in range(2)]
     test = AllBooleanFunctionsQuantSubst(mgr, vars, vars)
     test.basic()
+    test.subst()
     test.quant()
 
 

--- a/bindings/python/oxidd/tests/test_boolean_function.py
+++ b/bindings/python/oxidd/tests/test_boolean_function.py
@@ -8,6 +8,7 @@ from oxidd.protocols import (
     BooleanFunctionQuant,
     FunctionSubst,
 )
+from oxidd.util import BooleanOperator
 
 # spell-checker:ignore nvars,BFQS
 
@@ -285,6 +286,36 @@ class AllBooleanFunctionsQuantSubst(AllBooleanFunctions[BFQS]):
 
                 unique_actual = self._dd_to_boolean_func[f.unique(dd_var_set)]
                 assert unique_actual == unique_expected
+
+                for g in self._boolean_functions:
+                    for op in BooleanOperator:
+                        if op == BooleanOperator.AND:
+                            inner = f & g
+                        elif op == BooleanOperator.OR:
+                            inner = f | g
+                        elif op == BooleanOperator.XOR:
+                            inner = f ^ g
+                        elif op == BooleanOperator.EQUIV:
+                            inner = f.equiv(g)
+                        elif op == BooleanOperator.NAND:
+                            inner = f.nand(g)
+                        elif op == BooleanOperator.NOR:
+                            inner = f.nor(g)
+                        elif op == BooleanOperator.IMP:
+                            inner = f.imp(g)
+                        elif op == BooleanOperator.IMP_STRICT:
+                            inner = f.imp_strict(g)
+                        else:
+                            raise RuntimeError("Unknown operator")
+
+                        expected = inner.forall(dd_var_set)
+                        assert f.apply_forall(op, g, dd_var_set) == expected
+
+                        expected = inner.exist(dd_var_set)
+                        assert f.apply_exist(op, g, dd_var_set) == expected
+
+                        expected = inner.unique(dd_var_set)
+                        assert f.apply_unique(op, g, dd_var_set) == expected
 
 
 def test_bdd_all_boolean_functions_2vars_t1():

--- a/bindings/python/oxidd/util.py
+++ b/bindings/python/oxidd/util.py
@@ -1,7 +1,8 @@
 """Primitives and utilities"""
 
-__all__ = ["Assignment"]
+__all__ = ["BooleanOperator", "Assignment"]
 
+import enum
 from collections.abc import Iterator, Sequence
 from typing import Optional, Union
 
@@ -11,6 +12,27 @@ from typing_extensions import Never, Self, overload, override
 
 #: CFFI allocator that does not zero the newly allocated region
 _alloc = _ffi.new_allocator(should_clear_after_alloc=False)
+
+
+class BooleanOperator(enum.IntEnum):
+    """Binary operators on Boolean functions"""
+
+    AND = _lib.OXIDD_BOOLEAN_OPERATOR_AND
+    """Conjunction ``lhs ∧ rhs``"""
+    OR = _lib.OXIDD_BOOLEAN_OPERATOR_OR
+    """Disjunction ``lhs ∨ rhs``"""
+    XOR = _lib.OXIDD_BOOLEAN_OPERATOR_XOR
+    """Exclusive disjunction ``lhs ⊕ rhs``"""
+    EQUIV = _lib.OXIDD_BOOLEAN_OPERATOR_EQUIV
+    """Equivalence ``lhs ↔ rhs``"""
+    NAND = _lib.OXIDD_BOOLEAN_OPERATOR_NAND
+    """Negated conjunction ``lhs ⊼ rhs``"""
+    NOR = _lib.OXIDD_BOOLEAN_OPERATOR_NOR
+    """Negated disjunction ``lhs ⊽ rhs``"""
+    IMP = _lib.OXIDD_BOOLEAN_OPERATOR_IMP
+    """Implication ``lhs → rhs``"""
+    IMP_STRICT = _lib.OXIDD_BOOLEAN_OPERATOR_IMP_STRICT
+    """Strict implication ``lhs < rhs``"""
 
 
 class Assignment(Sequence[Optional[bool]]):

--- a/bindings/python/oxidd/zbdd.py
+++ b/bindings/python/oxidd/zbdd.py
@@ -15,7 +15,7 @@ from . import protocols, util
 class ZBDDManager(protocols.BooleanFunctionManager["ZBDDFunction"]):
     """Manager for zero-suppressed binary decision diagrams"""
 
-    _mgr: ...  #: Wrapped FFI object
+    _mgr: ...  #: Wrapped FFI object (``oxidd_zbdd_manager_t``)
 
     def __init__(self, inner_node_capacity: int, apply_cache_size: int, threads: int):
         """Create a new manager
@@ -95,7 +95,7 @@ class ZBDDFunction(protocols.BooleanFunction):
     run out of memory.
     """
 
-    _func: ...  #: Wrapped FFI object
+    _func: ...  #: Wrapped FFI object (``oxidd_zbdd_t``)
 
     def __init__(self, _: Never):
         """Private constructor

--- a/crates/oxidd-core/src/util/mod.rs
+++ b/crates/oxidd-core/src/util/mod.rs
@@ -484,6 +484,7 @@ pub trait IsFloatingPoint {
 }
 
 // dirty hack until we have specialization
+/// cbindgen:ignore
 impl<T: std::ops::ShlAssign<i32>> IsFloatingPoint for T {
     const FLOATING_POINT: bool = false;
 }

--- a/crates/oxidd-core/src/util/num.rs
+++ b/crates/oxidd-core/src/util/num.rs
@@ -15,6 +15,7 @@ use crate::util::IsFloatingPoint;
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Saturating<T>(pub T);
 
+/// cbindgen:ignore
 impl<T> IsFloatingPoint for Saturating<T> {
     const FLOATING_POINT: bool = false;
 }
@@ -95,6 +96,7 @@ impl ShlAssign<u32> for Saturating<u128> {
 /// Floating point number like [`f64`], but with [`ShlAssign<u32>`] and
 /// [`ShrAssign<u32>`].
 #[derive(Clone, Copy, PartialEq, PartialOrd)]
+#[repr(transparent)]
 pub struct F64(pub f64);
 
 impl From<u32> for F64 {
@@ -103,6 +105,7 @@ impl From<u32> for F64 {
     }
 }
 
+/// cbindgen:ignore
 impl IsFloatingPoint for F64 {
     const FLOATING_POINT: bool = true;
 }

--- a/crates/oxidd-ffi/cbindgen.toml
+++ b/crates/oxidd-ffi/cbindgen.toml
@@ -183,7 +183,7 @@ exclude = []
 
 # A prefix to add before the name of every item
 # default: no prefix is added
-prefix = ""
+prefix = "oxidd_"
 
 # Types of items that we'll generate. If empty, then all types of item are emitted.
 #
@@ -218,14 +218,16 @@ item_types = []
 # "MyType => capi_my_cool_type"
 #
 # default: false
-renaming_overrides_prefixing = true
+renaming_overrides_prefixing = false
 
+[export.rename]
+"LevelNo" = "level_no_t"
 
 # Configuration for name mangling
 [export.mangle]
 # Whether the types should be renamed during mangling, for example
 # c_char -> CChar, etc.
-#rename_types = "SnakeCase"
+rename_types = "SnakeCase"
 # Whether the underscores from the mangled name should be omitted.
 remove_underscores = false
 
@@ -410,7 +412,7 @@ derive_gte = false
 # * "GeckoCase": apply no renaming
 #
 # default: "None"
-rename_variants = "None"
+rename_variants = "QualifiedScreamingSnakeCase"
 
 # Whether an extra "sentinel" enum variant should be added to all generated enums.
 # Firefox uses this for their IPC serialization library.
@@ -507,7 +509,7 @@ allow_static_const = true
 # Whether a generated constant can be constexpr in C++ mode.
 #
 # default: true
-allow_constexpr = false
+allow_constexpr = true
 
 # This rule specifies the order in which constants will be sorted.
 #
@@ -529,13 +531,13 @@ bitflags = false
 [parse]
 # Whether to parse dependent crates and include their types in the output
 # default: false
-parse_deps = false
+parse_deps = true
 
 # A white list of crate names that are allowed to be parsed. If this is defined,
 # only crates found in this list will ever be parsed.
 #
 # default: there is no whitelist (NOTE: this is the opposite of [])
-include = []
+include = ["oxidd-core"]
 
 # A black list of crate names that are not allowed to be parsed.
 # default: []

--- a/crates/oxidd-ffi/cbindgen.toml
+++ b/crates/oxidd-ffi/cbindgen.toml
@@ -221,6 +221,7 @@ item_types = []
 renaming_overrides_prefixing = false
 
 [export.rename]
+"BooleanOperator" = "boolean_operator"
 "LevelNo" = "level_no_t"
 
 # Configuration for name mangling

--- a/crates/oxidd-ffi/src/bcdd.rs
+++ b/crates/oxidd-ffi/src/bcdd.rs
@@ -13,6 +13,7 @@ use oxidd::{
 
 // We need to use the following items from `oxidd_core` since cbindgen only
 // parses `oxidd_ffi` and `oxidd_core`:
+use oxidd_core::function::BooleanOperator;
 use oxidd_core::LevelNo;
 
 use crate::util::{assignment_t, FUNC_UNWRAP_MSG};
@@ -618,6 +619,69 @@ pub unsafe extern "C" fn oxidd_bcdd_exist(f: bcdd_t, var: bcdd_t) -> bcdd_t {
 #[no_mangle]
 pub unsafe extern "C" fn oxidd_bcdd_unique(f: bcdd_t, var: bcdd_t) -> bcdd_t {
     op2(f, var, BCDDFunction::unique)
+}
+
+/// Combined application of `op` and `oxidd_bcdd_forall()`
+///
+/// Passing a number as `op` that is not a valid `oxidd_boolean_operator`
+/// results in undefined behavior.
+///
+/// Locking behavior: acquires the manager's lock for shared access.
+///
+/// @returns  The BCDD function `∀ vars. lhs <op> rhs` with its own reference
+///           count
+#[no_mangle]
+pub unsafe extern "C" fn oxidd_bcdd_apply_forall(
+    op: BooleanOperator,
+    lhs: bcdd_t,
+    rhs: bcdd_t,
+    vars: bcdd_t,
+) -> bcdd_t {
+    lhs.get()
+        .and_then(|f| f.apply_forall(op, &*rhs.get()?, &*vars.get()?))
+        .into()
+}
+
+/// Combined application of `op` and `oxidd_bcdd_exist()`
+///
+/// Passing a number as `op` that is not a valid `oxidd_boolean_operator`
+/// results in undefined behavior.
+///
+/// Locking behavior: acquires the manager's lock for shared access.
+///
+/// @returns  The BCDD function `∃ vars. lhs <op> rhs` with its own reference
+///           count
+#[no_mangle]
+pub unsafe extern "C" fn oxidd_bcdd_apply_exist(
+    op: BooleanOperator,
+    lhs: bcdd_t,
+    rhs: bcdd_t,
+    vars: bcdd_t,
+) -> bcdd_t {
+    lhs.get()
+        .and_then(|f| f.apply_exist(op, &*rhs.get()?, &*vars.get()?))
+        .into()
+}
+
+/// Combined application of `op` and `oxidd_bcdd_unique()`
+///
+/// Passing a number as `op` that is not a valid `oxidd_boolean_operator`
+/// results in undefined behavior.
+///
+/// Locking behavior: acquires the manager's lock for shared access.
+///
+/// @returns  The BCDD function `∃! vars. lhs <op> rhs` with its own reference
+///           count
+#[no_mangle]
+pub unsafe extern "C" fn oxidd_bcdd_apply_unique(
+    op: BooleanOperator,
+    lhs: bcdd_t,
+    rhs: bcdd_t,
+    vars: bcdd_t,
+) -> bcdd_t {
+    lhs.get()
+        .and_then(|f| f.apply_unique(op, &*rhs.get()?, &*vars.get()?))
+        .into()
 }
 
 /// Count nodes in `f`

--- a/crates/oxidd-ffi/src/bdd.rs
+++ b/crates/oxidd-ffi/src/bdd.rs
@@ -13,6 +13,7 @@ use oxidd::{
 
 // We need to use the following items from `oxidd_core` since cbindgen only
 // parses `oxidd_ffi` and `oxidd_core`:
+use oxidd_core::function::BooleanOperator;
 use oxidd_core::LevelNo;
 
 use crate::util::{assignment_t, FUNC_UNWRAP_MSG};
@@ -611,6 +612,69 @@ pub unsafe extern "C" fn oxidd_bdd_exist(f: bdd_t, vars: bdd_t) -> bdd_t {
 #[no_mangle]
 pub unsafe extern "C" fn oxidd_bdd_unique(f: bdd_t, vars: bdd_t) -> bdd_t {
     op2(f, vars, BDDFunction::unique)
+}
+
+/// Combined application of `op` and `oxidd_bdd_forall()`
+///
+/// Passing a number as `op` that is not a valid `oxidd_boolean_operator`
+/// results in undefined behavior.
+///
+/// Locking behavior: acquires the manager's lock for shared access.
+///
+/// @returns  The BDD function `∀ vars. lhs <op> rhs` with its own reference
+///           count
+#[no_mangle]
+pub unsafe extern "C" fn oxidd_bdd_apply_forall(
+    op: BooleanOperator,
+    lhs: bdd_t,
+    rhs: bdd_t,
+    vars: bdd_t,
+) -> bdd_t {
+    lhs.get()
+        .and_then(|f| f.apply_forall(op, &*rhs.get()?, &*vars.get()?))
+        .into()
+}
+
+/// Combined application of `op` and `oxidd_bdd_exist()`
+///
+/// Passing a number as `op` that is not a valid `oxidd_boolean_operator`
+/// results in undefined behavior.
+///
+/// Locking behavior: acquires the manager's lock for shared access.
+///
+/// @returns  The BDD function `∃ vars. lhs <op> rhs` with its own reference
+///           count
+#[no_mangle]
+pub unsafe extern "C" fn oxidd_bdd_apply_exist(
+    op: BooleanOperator,
+    lhs: bdd_t,
+    rhs: bdd_t,
+    vars: bdd_t,
+) -> bdd_t {
+    lhs.get()
+        .and_then(|f| f.apply_exist(op, &*rhs.get()?, &*vars.get()?))
+        .into()
+}
+
+/// Combined application of `op` and `oxidd_bdd_unique()`
+///
+/// Passing a number as `op` that is not a valid `oxidd_boolean_operator`
+/// results in undefined behavior.
+///
+/// Locking behavior: acquires the manager's lock for shared access.
+///
+/// @returns  The BDD function `∃! vars. lhs <op> rhs` with its own reference
+///           count
+#[no_mangle]
+pub unsafe extern "C" fn oxidd_bdd_apply_unique(
+    op: BooleanOperator,
+    lhs: bdd_t,
+    rhs: bdd_t,
+    vars: bdd_t,
+) -> bdd_t {
+    lhs.get()
+        .and_then(|f| f.apply_unique(op, &*rhs.get()?, &*vars.get()?))
+        .into()
 }
 
 /// Count nodes in `f`

--- a/crates/oxidd-ffi/src/lib.rs
+++ b/crates/oxidd-ffi/src/lib.rs
@@ -4,6 +4,15 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::forget_non_drop)]
 
+// Some general notes: cbindgen will prefix all types with `oxidd_`, and
+// additionally rename:
+//
+// - `LevelNo` into `oxidd_level_no_t`
+//
+// Renaming is not applied in docstrings, we manually enter the C symbol name
+// there. Furthermore, renaming does not work for function names, we manually
+// prefix them with `oxidd_`.
+
 // These modules are not `pub` because they are not intended to be used from
 // Rust code.
 mod util;

--- a/crates/oxidd-ffi/src/lib.rs
+++ b/crates/oxidd-ffi/src/lib.rs
@@ -7,6 +7,7 @@
 // Some general notes: cbindgen will prefix all types with `oxidd_`, and
 // additionally rename:
 //
+// - `BooleanOperator` into `oxidd_boolean_operator`
 // - `LevelNo` into `oxidd_level_no_t`
 //
 // Renaming is not applied in docstrings, we manually enter the C symbol name

--- a/crates/oxidd-ffi/src/util.rs
+++ b/crates/oxidd-ffi/src/util.rs
@@ -1,15 +1,14 @@
 use oxidd_core::util::Substitution;
 
-/// Level number type
-#[allow(non_camel_case_types)]
-pub type oxidd_level_no_t = u32;
+/// cbindgen:ignore
+pub const FUNC_UNWRAP_MSG: &str = "the given function is invalid";
 
 /// Boolean assignment
 ///
 /// `data` is a pointer to `len` values. A value can be either 0 (false), 1
 /// (true), or -1 (don't care).
 #[repr(C)]
-pub struct oxidd_assignment_t {
+pub struct assignment_t {
     /// Pointer to the data array of length `len`
     ///
     /// Must never be modified
@@ -28,7 +27,7 @@ pub struct oxidd_assignment_t {
 ///
 /// In case `assignment.data` is `NULL`, this is a no-op.
 #[no_mangle]
-pub unsafe extern "C" fn oxidd_assignment_free(assignment: oxidd_assignment_t) {
+pub unsafe extern "C" fn oxidd_assignment_free(assignment: assignment_t) {
     if !assignment.data.is_null() {
         drop(Vec::from_raw_parts(
             assignment.data,

--- a/crates/oxidd-manager-index/src/terminal_manager/dynamic.rs
+++ b/crates/oxidd-manager-index/src/terminal_manager/dynamic.rs
@@ -62,7 +62,7 @@ struct ArcItem<T> {
 /// SAFETY: `id` must be a valid terminal ID for `store`
 unsafe fn retain<T>(store: &[UnsafeCell<Slot<T>>], id: usize) {
     // SAFETY: Since `id` is a valid terminal ID, it is `<= store.len()`.
-    // Futhermore, we have shared access to the referenced slot and the `Slot`
+    // Furthermore, we have shared access to the referenced slot and the `Slot`
     // is a `node`.
     let item = unsafe { &(*store.get_unchecked(id).get()).node };
     let old_rc = item.rc.fetch_add(1, Relaxed);
@@ -127,7 +127,7 @@ where
     #[inline]
     unsafe fn get_terminal(&self, id: usize) -> &T {
         // SAFETY: Since `id` is a valid terminal ID, it is
-        // `<= self.store.len()`. Futhermore, we have shared access to the
+        // `<= self.store.len()`. Furthermore, we have shared access to the
         // referenced `Slot` and the slot is a `node`.
         &unsafe { &(*self.store.get_unchecked(id).get()).node }.value
     }
@@ -141,7 +141,7 @@ where
     #[inline]
     unsafe fn release(&self, id: usize) {
         // SAFETY: Since `id` is a valid terminal ID, it is
-        // `<= self.store.len()`. Futhermore, we have shared access to the
+        // `<= self.store.len()`. Furthermore, we have shared access to the
         // referenced `Slot` and the slot is a `node`.
         let item = unsafe { &(*self.store.get_unchecked(id).get()).node };
         // Synchronizes-with the load in `Self::gc()`

--- a/crates/oxidd-rules-bdd/src/simple/mod.rs
+++ b/crates/oxidd-rules-bdd/src/simple/mod.rs
@@ -286,6 +286,77 @@ pub enum BDDOp {
     Exist,
     /// Unique quantification
     Unique,
+
+    ForallAnd,
+    ForallOr,
+    ForallNand,
+    ForallNor,
+    ForallXor,
+    ForallEquiv,
+    ForallImp,
+    ForallImpStrict,
+
+    ExistAnd,
+    ExistOr,
+    ExistNand,
+    ExistNor,
+    ExistXor,
+    ExistEquiv,
+    ExistImp,
+    ExistImpStrict,
+
+    UniqueAnd,
+    UniqueOr,
+    UniqueNand,
+    UniqueNor,
+    UniqueXor,
+    UniqueEquiv,
+    UniqueImp,
+    UniqueImpStrict,
+}
+
+impl BDDOp {
+    const fn from_apply_quant(q: u8, op: u8) -> Self {
+        if q == BDDOp::And as u8 {
+            match () {
+                _ if op == BDDOp::And as u8 => BDDOp::ForallAnd,
+                _ if op == BDDOp::Or as u8 => BDDOp::ForallOr,
+                _ if op == BDDOp::Nand as u8 => BDDOp::ForallNand,
+                _ if op == BDDOp::Nor as u8 => BDDOp::ForallNor,
+                _ if op == BDDOp::Xor as u8 => BDDOp::ForallXor,
+                _ if op == BDDOp::Equiv as u8 => BDDOp::ForallEquiv,
+                _ if op == BDDOp::Imp as u8 => BDDOp::ForallImp,
+                _ if op == BDDOp::ImpStrict as u8 => BDDOp::ForallImpStrict,
+                _ => panic!("invalid OP"),
+            }
+        } else if q == BDDOp::Or as u8 {
+            match () {
+                _ if op == BDDOp::And as u8 => BDDOp::ExistAnd,
+                _ if op == BDDOp::Or as u8 => BDDOp::ExistOr,
+                _ if op == BDDOp::Nand as u8 => BDDOp::ExistNand,
+                _ if op == BDDOp::Nor as u8 => BDDOp::ExistNor,
+                _ if op == BDDOp::Xor as u8 => BDDOp::ExistXor,
+                _ if op == BDDOp::Equiv as u8 => BDDOp::ExistEquiv,
+                _ if op == BDDOp::Imp as u8 => BDDOp::ExistImp,
+                _ if op == BDDOp::ImpStrict as u8 => BDDOp::ExistImpStrict,
+                _ => panic!("invalid OP"),
+            }
+        } else if q == BDDOp::Xor as u8 {
+            match () {
+                _ if op == BDDOp::And as u8 => BDDOp::UniqueAnd,
+                _ if op == BDDOp::Or as u8 => BDDOp::UniqueOr,
+                _ if op == BDDOp::Nand as u8 => BDDOp::UniqueNand,
+                _ if op == BDDOp::Nor as u8 => BDDOp::UniqueNor,
+                _ if op == BDDOp::Xor as u8 => BDDOp::UniqueXor,
+                _ if op == BDDOp::Equiv as u8 => BDDOp::UniqueEquiv,
+                _ if op == BDDOp::Imp as u8 => BDDOp::UniqueImp,
+                _ if op == BDDOp::ImpStrict as u8 => BDDOp::UniqueImpStrict,
+                _ => panic!("invalid OP"),
+            }
+        } else {
+            panic!("invalid quantifier");
+        }
+    }
 }
 
 enum Operation<'a, E: 'a + Edge> {

--- a/crates/oxidd/src/lib.rs
+++ b/crates/oxidd/src/lib.rs
@@ -12,21 +12,12 @@ std::compile_error!(
     "Either feature `manager-index` or `manager-pointer` must be enabled for this crate"
 );
 
-pub use oxidd_core::function::BooleanFunction;
-pub use oxidd_core::function::BooleanFunctionQuant;
-pub use oxidd_core::function::BooleanVecSet;
-pub use oxidd_core::function::Function;
-pub use oxidd_core::function::FunctionSubst;
-pub use oxidd_core::function::NumberBase;
-pub use oxidd_core::function::PseudoBooleanFunction;
-pub use oxidd_core::function::TVLFunction;
+pub use oxidd_core::function::{
+    BooleanFunction, BooleanFunctionQuant, BooleanOperator, BooleanVecSet, Function, FunctionSubst,
+    NumberBase, PseudoBooleanFunction, TVLFunction,
+};
 pub use oxidd_core::util::{Subst, Substitution};
-pub use oxidd_core::Edge;
-pub use oxidd_core::InnerNode;
-pub use oxidd_core::LevelNo;
-pub use oxidd_core::Manager;
-pub use oxidd_core::ManagerRef;
-pub use oxidd_core::NodeID;
+pub use oxidd_core::{Edge, InnerNode, LevelNo, Manager, ManagerRef, NodeID};
 
 pub mod util;
 

--- a/crates/oxidd/src/util/apply_cache.rs
+++ b/crates/oxidd/src/util/apply_cache.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 
-use oxidd_core::util::Borrowed;
+use oxidd_core::util::{Borrowed, GCContainer};
 use oxidd_core::Manager;
 
 cfg_if::cfg_if! {
@@ -39,6 +39,16 @@ impl<M: Manager, O: Copy, const ARITY: usize> oxidd_core::util::DropWith<M::Edge
 {
     #[inline(always)]
     fn drop_with(self, _drop_edge: impl Fn(M::Edge)) {
+        // Nothing to do
+    }
+}
+
+impl<M: Manager, O, const ARITY: usize> GCContainer<M> for NoApplyCache<M, O, ARITY> {
+    fn pre_gc(&self, _manager: &M) {
+        // Nothing to do
+    }
+
+    unsafe fn post_gc(&self, _manager: &M) {
         // Nothing to do
     }
 }

--- a/crates/oxidd/tests/boolean_function.rs
+++ b/crates/oxidd/tests/boolean_function.rs
@@ -793,6 +793,50 @@ impl<'a, B: BooleanFunctionQuant> TestAllBooleanFunctions<'a, B> {
                     &[f_explicit],
                     &[var_set],
                 );
+
+                // Apply and quantification algorithms. Here, we only compare the naive and
+                // optimized implementations.
+                let f_explicit = f_explicit as ExplicitBFunc;
+                for (g_explicit, g) in self.boolean_functions.iter().enumerate() {
+                    let g_explicit = g_explicit as ExplicitBFunc;
+                    use BooleanOperator::*;
+                    for op in [And, Or, Xor, Equiv, Nand, Nor, Imp, ImpStrict] {
+                        let (inner, inner_symbol) = match op {
+                            And => (f.and(g).unwrap(), "∧"),
+                            Or => (f.or(g).unwrap(), "∨"),
+                            Xor => (f.xor(g).unwrap(), "⊕"),
+                            Equiv => (f.equiv(g).unwrap(), "↔"),
+                            Nand => (f.nand(g).unwrap(), "⊼"),
+                            Nor => (f.nor(g).unwrap(), "⊽"),
+                            Imp => (f.imp(g).unwrap(), "→"),
+                            ImpStrict => (f.imp_strict(g).unwrap(), "<"),
+                        };
+
+                        self.check(
+                            format_args!("∃v. f {inner_symbol} g"),
+                            self.dd_to_boolean_func[&f.apply_exist(op, g, &dd_var_set).unwrap()],
+                            self.dd_to_boolean_func[&inner.exist(&dd_var_set).unwrap()],
+                            &[f_explicit, g_explicit],
+                            &[var_set],
+                        );
+
+                        self.check(
+                            format_args!("∀v. f {inner_symbol} g"),
+                            self.dd_to_boolean_func[&f.apply_forall(op, g, &dd_var_set).unwrap()],
+                            self.dd_to_boolean_func[&inner.forall(&dd_var_set).unwrap()],
+                            &[f_explicit, g_explicit],
+                            &[var_set],
+                        );
+
+                        self.check(
+                            format_args!("∃!v. f {inner_symbol} g"),
+                            self.dd_to_boolean_func[&f.apply_unique(op, g, &dd_var_set).unwrap()],
+                            self.dd_to_boolean_func[&inner.unique(&dd_var_set).unwrap()],
+                            &[f_explicit, g_explicit],
+                            &[var_set],
+                        );
+                    }
+                }
             }
         }
     }

--- a/crates/oxidd/tests/util/debug.rs
+++ b/crates/oxidd/tests/util/debug.rs
@@ -1,0 +1,84 @@
+use std::fmt::{Debug, Display, Formatter, Result, Write};
+
+pub type ExplicitBFunc = u32;
+
+pub struct TruthTable {
+    pub(crate) vars: u32,
+    pub(crate) columns: Vec<(String, ExplicitBFunc)>,
+}
+
+impl Display for TruthTable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let mut table_width = 0;
+        for var in 0..self.vars {
+            write!(f, " x{var} |")?;
+            table_width += 5 + if var == 0 { 0 } else { var.ilog10() };
+        }
+        for (column, _) in &self.columns {
+            write!(f, "| {column} ")?;
+            table_width += 3 + column.len() as u32;
+        }
+        writeln!(f)?;
+        for _ in 0..table_width {
+            f.write_char('-')?;
+        }
+        writeln!(f)?;
+        for assignment in 0..1u32 << self.vars {
+            for var in 0..self.vars {
+                let width = 2 + if var == 0 { 0 } else { var.ilog10() } as usize;
+                let val = (assignment >> var) & 1;
+                write!(f, " {val:>width$} |")?;
+            }
+            for (name, func) in &self.columns {
+                let width = name.len();
+                let val = (func >> assignment) & 1;
+                write!(f, "| {val:>width$} ")?;
+            }
+            writeln!(f)?;
+        }
+        Ok(())
+    }
+}
+impl Debug for TruthTable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        Display::fmt(self, f)
+    }
+}
+
+pub struct VarSet {
+    vars: u32,
+    set: u32,
+}
+
+impl Debug for VarSet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let mut list = f.debug_list();
+        for i in 0..self.vars {
+            if (self.set >> i) & 1 != 0 {
+                list.entry(&format_args!("x{i}"));
+            }
+        }
+        list.finish()
+    }
+}
+
+pub struct SetList<'a> {
+    pub(crate) vars: u32,
+    pub(crate) sets: &'a [u32],
+}
+
+impl<'a> Debug for SetList<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let mut map = f.debug_map();
+        let vars = self.vars;
+        if self.sets.len() == 1 {
+            let set = self.sets[0];
+            map.entry(&format_args!("v"), &VarSet { vars, set });
+        } else {
+            for (i, &set) in self.sets.iter().enumerate() {
+                map.entry(&format_args!("v{i}"), &VarSet { vars, set });
+            }
+        }
+        map.finish()
+    }
+}

--- a/crates/oxidd/tests/util/mod.rs
+++ b/crates/oxidd/tests/util/mod.rs
@@ -1,1 +1,2 @@
+pub mod debug;
 pub mod progress;


### PR DESCRIPTION
This pull request introduces the `apply_{forall,exist,unique}` functions for `BooleanFunctionQuant`, which computes apply followed by quantification.

 - Introduced `BooleanOperator` to specify the operation to apply.
 - Added the default implementation for all DD variants.
 - Implemented a specialized variant, both single and multi-threaded, of the apply_quant for BDDs.
 - Added tests for the introduced functions. The single threaded variant requires `multi-threaded` to be removed from the default features of oxidd to run the tests.
 - This should not strictly belong in this pull request, but when trying to do some benchmarking it turned out that the `NoApplyCache` variant did not compile.

TODO:
 - Extend the interfaces for Python and C++ .
 - There are no benchmarks added to show that the implemented procedure is actually more optimal than the naive version. This could be considered future work.