### PR TITLE
fix cofactor_false in cpp bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 project(OxiDD
-    VERSION 0.10.0
+    VERSION 0.10.1
     DESCRIPTION "Concurrent Decision Diagram Library"
     HOMEPAGE_URL "https://oxidd.net"
     LANGUAGES CXX)

--- a/bindings/cpp/include/oxidd/bcdd.hpp
+++ b/bindings/cpp/include/oxidd/bcdd.hpp
@@ -366,7 +366,7 @@ public:
   /// @returns  `f_false` if `f` is valid and references an inner node,
   ///           otherwise an invalid function.
   [[nodiscard]] bcdd_function cofactor_false() const noexcept {
-    return capi::oxidd_bcdd_cofactor_true(_func);
+    return capi::oxidd_bcdd_cofactor_false(_func);
   }
 
   /// Get the level of the underlying node

--- a/bindings/cpp/include/oxidd/bdd.hpp
+++ b/bindings/cpp/include/oxidd/bdd.hpp
@@ -369,7 +369,7 @@ public:
   /// @returns  `f_false` if `f` is valid and references an inner node,
   ///           otherwise an invalid function.
   [[nodiscard]] bdd_function cofactor_false() const noexcept {
-    return capi::oxidd_bdd_cofactor_true(_func);
+    return capi::oxidd_bdd_cofactor_false(_func);
   }
 
   /// Get the level of the underlying node

--- a/bindings/cpp/include/oxidd/zbdd.hpp
+++ b/bindings/cpp/include/oxidd/zbdd.hpp
@@ -379,7 +379,7 @@ public:
   /// @returns  `f_false` if `f` is valid and references an inner node,
   ///           otherwise an invalid function.
   [[nodiscard]] zbdd_function cofactor_false() const noexcept {
-    return capi::oxidd_zbdd_cofactor_true(_func);
+    return capi::oxidd_zbdd_cofactor_false(_func);
   }
 
   /// Get the level of the underlying node

--- a/bindings/cpp/tests/boolean-function.cpp
+++ b/bindings/cpp/tests/boolean-function.cpp
@@ -568,6 +568,27 @@ public:
   }
 };
 
+template <boolean_function F>
+void test_cofactors(const F &ff, const F &tt, slice<F> vars) {
+  const auto [ff_t, ff_e] = ff.cofactors();
+  assert(ff_t.is_invalid() && ff_e.is_invalid());
+  assert(ff.cofactor_true().is_invalid());
+  assert(ff.cofactor_false().is_invalid());
+
+  const auto [tt_t, tt_e] = tt.cofactors();
+  assert(tt_t.is_invalid() && tt_e.is_invalid());
+  assert(tt.cofactor_true().is_invalid());
+  assert(tt.cofactor_false().is_invalid());
+
+  for (const F &v : vars) {
+    const auto [v_t, v_e] = v.cofactors();
+    assert(v_t == v.cofactor_true());
+    assert(v_e == v.cofactor_false());
+    assert(v_t == tt);
+    assert(v_e == ff);
+  }
+}
+
 void bdd_all_boolean_functions_2vars_t1() {
   // NOLINTNEXTLINE(*-magic-numbers)
   bdd_manager mgr(65536, 1024, 1);
@@ -577,6 +598,8 @@ void bdd_all_boolean_functions_2vars_t1() {
     test.basic();
     test.subst();
     test.quant();
+
+    test_cofactors<bdd_function>(mgr.f(), mgr.t(), vars);
   });
 }
 
@@ -589,6 +612,8 @@ void bcdd_all_boolean_functions_2vars_t1() {
     test.basic();
     test.subst();
     test.quant();
+
+    test_cofactors<bcdd_function>(mgr.f(), mgr.t(), vars);
   });
 }
 
@@ -601,6 +626,10 @@ void zbdd_all_boolean_functions_2vars_t1() {
                           singletons[1].var_boolean_function()};
     const test_all_boolean_functions test(mgr, vars, singletons);
     test.basic();
+
+    // The test function only operates on structural properties, so we can reuse
+    // it here with `mgr.base()` and the singleton sets.
+    test_cofactors<zbdd_function>(mgr.empty(), mgr.base(), singletons);
   });
 }
 


### PR DESCRIPTION
Fixes a bug in the cofactor_false function in the cpp bindings.

Any plans for a test-suite for these bindings?