### PR TITLE
Added visualization export function

### DIFF
--- a/crates/oxidd-cli/Cargo.toml
+++ b/crates/oxidd-cli/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 
 
 [dependencies]
-oxidd = { workspace = true, features = ["bdd", "bcdd"] }
+oxidd = { workspace = true, features = ["bdd", "bcdd", "dddmp", "dot-export"] }
 oxidd-core.workspace = true
 oxidd-dump.workspace = true
 oxidd-reorder.workspace = true

--- a/crates/oxidd-cli/src/main.rs
+++ b/crates/oxidd-cli/src/main.rs
@@ -211,7 +211,8 @@ where
     for<'id> B::Manager<'id>: HasWorkers + HasApplyCache<B::Manager<'id>, O>,
     for<'id> <B::Manager<'id> as Manager>::InnerNode: HasLevel,
     for<'id> <B::Manager<'id> as Manager>::EdgeTag: fmt::Debug,
-    for<'id> <B::Manager<'id> as Manager>::Terminal: FromStr + fmt::Display + dddmp::AsciiDisplay,
+    for<'id> <B::Manager<'id> as Manager>::Terminal:
+        FromStr + fmt::Display + oxidd_dump::AsciiDisplay,
     O: Copy + Ord + Hash,
 {
     let parse_options = ParseOptionsBuilder::default()

--- a/crates/oxidd-core/src/function.rs
+++ b/crates/oxidd-core/src/function.rs
@@ -45,6 +45,9 @@ pub type INodeOfFunc<'id, F> = <<F as Function>::Manager<'id> as Manager>::Inner
 /// maintain this link accordingly. In particular, [`Self::as_edge()`] and
 /// [`Self::into_edge()`] must panic as specified there.
 pub unsafe trait Function: Clone + Ord + Hash {
+    /// Representation identifier such as "BDD" or "MTBDD"
+    const REPR_ID: &str; // `str` and not an `enum` for extensibility
+
     /// Type of the associated manager
     ///
     /// This type is generic over a lifetime `'id` to permit the "lifetime

--- a/crates/oxidd-derive/src/lib.rs
+++ b/crates/oxidd-derive/src/lib.rs
@@ -33,8 +33,11 @@ pub fn derive_countable(input: proc_macro::TokenStream) -> proc_macro::TokenStre
 ///
 /// You may specify the associated `ManagerRef` type using an attribute
 /// `#[use_manager_ref(YourManagerRefType)]`.
+///
+/// To influence the representation identifier, use the attribute
+/// `#[repr_id = "MY_BDD"]`.
 #[proc_macro_error::proc_macro_error]
-#[proc_macro_derive(Function, attributes(use_manager_ref))]
+#[proc_macro_derive(Function, attributes(use_manager_ref, repr_id))]
 pub fn derive_function(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
     let expanded = function::derive_function(input);

--- a/crates/oxidd-dump/Cargo.toml
+++ b/crates/oxidd-dump/Cargo.toml
@@ -40,7 +40,7 @@ document-features = "0.2"
 default = ["dddmp", "dot"]
 
 ## DDDMP format originally from CUDD
-dddmp = ["bitvec", "rustc-hash", "memchr", "is_sorted"]
+dddmp = ["dep:bitvec", "dep:rustc-hash", "dep:memchr", "dep:is_sorted"]
 
-## Visualization using dot
+## Visualization using Graphviz DOT
 dot = []

--- a/crates/oxidd-dump/Cargo.toml
+++ b/crates/oxidd-dump/Cargo.toml
@@ -37,10 +37,13 @@ document-features = "0.2"
 
 
 [features]
-default = ["dddmp", "dot"]
+default = ["dddmp", "dot", "visualize"]
 
 ## DDDMP format originally from CUDD
 dddmp = ["dep:bitvec", "dep:rustc-hash", "dep:memchr", "dep:is_sorted"]
 
 ## Visualization using Graphviz DOT
 dot = []
+
+## Visualization using OxiDD-viz
+visualize = ["dddmp"]

--- a/crates/oxidd-dump/src/dddmp.rs
+++ b/crates/oxidd-dump/src/dddmp.rs
@@ -455,14 +455,8 @@ fn cmp_strict<T: Ord>(a: &T, b: &T) -> Option<std::cmp::Ordering> {
     Some(a.cmp(b).then(std::cmp::Ordering::Greater))
 }
 
-/// Like [`std::fmt::Display`], but the format should use ASCII characters only
-pub trait AsciiDisplay {
-    /// Format the value with the given formatter
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error>;
-}
-
 struct Ascii<T>(T);
-impl<T: AsciiDisplay> fmt::Display for Ascii<&T> {
+impl<T: crate::AsciiDisplay> fmt::Display for Ascii<&T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
@@ -500,7 +494,7 @@ pub fn export<'id, F: Function>(
 ) -> io::Result<()>
 where
     <F::Manager<'id> as Manager>::InnerNode: HasLevel,
-    <F::Manager<'id> as Manager>::Terminal: AsciiDisplay,
+    <F::Manager<'id> as Manager>::Terminal: crate::AsciiDisplay,
 {
     assert!(var_names.is_none() || var_names.unwrap().len() == vars.len());
     assert!(function_names.is_none() || function_names.unwrap().len() == functions.len());

--- a/crates/oxidd-dump/src/dot/dot_impl.rs
+++ b/crates/oxidd-dump/src/dot/dot_impl.rs
@@ -1,7 +1,3 @@
-//! Visual representation using [dot]
-//!
-//! [dot]: https://graphviz.org/docs/layouts/dot/
-
 use std::fmt;
 use std::io;
 
@@ -13,76 +9,6 @@ use oxidd_core::InnerNode;
 use oxidd_core::LevelNo;
 use oxidd_core::LevelView;
 use oxidd_core::Manager;
-use oxidd_core::Tag;
-
-/// Edge styles
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum EdgeStyle {
-    #[allow(missing_docs)]
-    Solid,
-    #[allow(missing_docs)]
-    Dashed,
-    #[allow(missing_docs)]
-    Dotted,
-}
-
-impl fmt::Display for EdgeStyle {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let str = match self {
-            EdgeStyle::Solid => "solid",
-            EdgeStyle::Dashed => "dashed",
-            EdgeStyle::Dotted => "dotted",
-        };
-        write!(f, "{str}")
-    }
-}
-
-/// RGB colors
-///
-/// `Color(0, 0, 0)` is black, `Color(255, 255, 255)` is white.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct Color(pub u8, pub u8, pub u8);
-
-impl Color {
-    #[allow(missing_docs)]
-    pub const BLACK: Self = Color(0, 0, 0);
-}
-
-impl fmt::Display for Color {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "#{:02X}{:02X}{:02X}", self.0, self.1, self.2)
-    }
-}
-
-/// Styling attributes defined by the node type
-pub trait DotStyle<T: Tag> {
-    /// Get the style for the `n`-th outgoing edge, tagged with `tag`
-    ///
-    /// Returns the edge style (solid/dashed/dotted), whether it is bold, and
-    /// the color.
-    ///
-    /// The default implementation distinguishes three kinds of edges (all
-    /// non-bold and black):
-    ///
-    /// 1. If the edge is tagged (i.e. `tag` is not the default value) then the
-    ///    edge is dotted.
-    /// 2. If the edge is untagged and the second edge (`no == 1`), then it is
-    ///    dashed
-    /// 3. Otherwise the edge is solid
-    fn edge_style(no: usize, tag: T) -> (EdgeStyle, bool, Color) {
-        (
-            if tag != Default::default() {
-                EdgeStyle::Dotted
-            } else if no == 1 {
-                EdgeStyle::Dashed
-            } else {
-                EdgeStyle::Solid
-            },
-            false,
-            Color::BLACK,
-        )
-    }
-}
 
 /// Dump the entire decision diagram represented by `manager` as Graphviz DOT
 /// code to `file`
@@ -99,7 +25,7 @@ pub fn dump_all<'a, 'id, F, VD, FD>(
     functions: impl IntoIterator<Item = (&'a F, FD)>,
 ) -> io::Result<()>
 where
-    F: 'a + Function + DotStyle<<<F::Manager<'id> as Manager>::Edge as Edge>::Tag>,
+    F: 'a + Function + super::DotStyle<<<F::Manager<'id> as Manager>::Edge as Edge>::Tag>,
     <F::Manager<'id> as Manager>::InnerNode: HasLevel,
     <<F::Manager<'id> as Manager>::Edge as Edge>::Tag: fmt::Debug,
     <F::Manager<'id> as Manager>::Terminal: fmt::Display,

--- a/crates/oxidd-dump/src/dot/mod.rs
+++ b/crates/oxidd-dump/src/dot/mod.rs
@@ -1,0 +1,80 @@
+//! Visual representation using [dot]
+//!
+//! [dot]: https://graphviz.org/docs/layouts/dot/
+
+use std::fmt;
+
+use oxidd_core::Tag;
+
+/// Edge styles
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum EdgeStyle {
+    #[allow(missing_docs)]
+    Solid,
+    #[allow(missing_docs)]
+    Dashed,
+    #[allow(missing_docs)]
+    Dotted,
+}
+
+impl fmt::Display for EdgeStyle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            EdgeStyle::Solid => "solid",
+            EdgeStyle::Dashed => "dashed",
+            EdgeStyle::Dotted => "dotted",
+        })
+    }
+}
+
+/// RGB colors
+///
+/// `Color(0, 0, 0)` is black, `Color(255, 255, 255)` is white.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Color(pub u8, pub u8, pub u8);
+
+impl Color {
+    #[allow(missing_docs)]
+    pub const BLACK: Self = Color(0, 0, 0);
+}
+
+impl fmt::Display for Color {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "#{:02X}{:02X}{:02X}", self.0, self.1, self.2)
+    }
+}
+
+/// Styling attributes defined by the node type
+pub trait DotStyle<T: Tag> {
+    /// Get the style for the `n`-th outgoing edge, tagged with `tag`
+    ///
+    /// Returns the edge style (solid/dashed/dotted), whether it is bold, and
+    /// the color.
+    ///
+    /// The default implementation distinguishes three kinds of edges (all
+    /// non-bold and black):
+    ///
+    /// 1. If the edge is tagged (i.e. `tag` is not the default value) then the
+    ///    edge is dotted.
+    /// 2. If the edge is untagged and the second edge (`no == 1`), then it is
+    ///    dashed
+    /// 3. Otherwise the edge is solid
+    fn edge_style(no: usize, tag: T) -> (EdgeStyle, bool, Color) {
+        (
+            if tag != Default::default() {
+                EdgeStyle::Dotted
+            } else if no == 1 {
+                EdgeStyle::Dashed
+            } else {
+                EdgeStyle::Solid
+            },
+            false,
+            Color::BLACK,
+        )
+    }
+}
+
+#[cfg(feature = "dot")]
+mod dot_impl;
+#[cfg(feature = "dot")]
+pub use dot_impl::dump_all;

--- a/crates/oxidd-dump/src/lib.rs
+++ b/crates/oxidd-dump/src/lib.rs
@@ -22,3 +22,6 @@ pub mod dddmp;
 
 // No feature gate here to always have the traits
 pub mod dot;
+
+#[cfg(feature = "visualize")]
+pub mod visualize;

--- a/crates/oxidd-dump/src/lib.rs
+++ b/crates/oxidd-dump/src/lib.rs
@@ -9,8 +9,16 @@
 // achieve this, we use assertions that evaluate to `true` on usual targets.
 #![allow(clippy::assertions_on_constants)]
 
+use std::fmt;
+
+/// Like [`std::fmt::Display`], but the format should use ASCII characters only
+pub trait AsciiDisplay {
+    /// Format the value with the given formatter
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error>;
+}
+
 #[cfg(feature = "dddmp")]
 pub mod dddmp;
 
-#[cfg(feature = "dot")]
+// No feature gate here to always have the traits
 pub mod dot;

--- a/crates/oxidd-dump/src/visualize.rs
+++ b/crates/oxidd-dump/src/visualize.rs
@@ -1,0 +1,171 @@
+//! Export the diagrams over http to other tools (polling for changes)
+
+use std::io;
+
+use std::io::{BufRead, Write};
+use std::net::TcpListener;
+
+use oxidd_core::{function::Function, HasLevel, Manager};
+
+/// Serve provided decision diagram for visualization
+///
+/// `dd_name` is the name that is sent to the visualization tool
+///
+/// `vars` are edges representing *all* variables in the decision diagram. The
+/// order does not matter. `var_names` are the names of these variables
+/// (optional). If given, there must be `vars.len()` names in the same order as
+/// in `vars`.
+///
+/// `functions` are edges pointing to the root nodes of functions.
+/// `function_names` are the corresponding names (optional). If given, there
+/// must be `functions.len()` names in the same order as in `function_names`.
+///
+/// `port` is the port to provide the data on, which defaults to 4000
+pub fn visualize<'id, F: Function>(
+    manager: &F::Manager<'id>,
+    dd_name: &str,
+    vars: &[&F],
+    var_names: Option<&[&str]>,
+    functions: &[&F],
+    function_names: Option<&[&str]>,
+    port: Option<u16>,
+) -> io::Result<()>
+where
+    <F::Manager<'id> as Manager>::InnerNode: HasLevel,
+    <F::Manager<'id> as Manager>::Terminal: crate::AsciiDisplay,
+{
+    visualize_all(
+        [VisualizationInput {
+            dd_name,
+            manager,
+            functions,
+            vars,
+            function_names,
+            var_names,
+        }],
+        port,
+    )
+}
+
+/// Serve provided decision diagram for visualization
+///
+/// `inputs` is the vector of visualizations to send all at once
+///
+/// `port` is the port to provide the data on, which defaults to 4000
+pub fn visualize_all<'a, 'id, F: Function + 'a>(
+    inputs: impl IntoIterator<Item = VisualizationInput<'a, 'id, F>>,
+    port: Option<u16>,
+) -> io::Result<()>
+where
+    F::Manager<'id>: 'a,
+    <F::Manager<'id> as Manager>::InnerNode: HasLevel,
+    <F::Manager<'id> as Manager>::Terminal: crate::AsciiDisplay,
+{
+    let port = port.unwrap_or(4000);
+
+    let mut body_buffer = Vec::with_capacity(2 * 1024 * 1024);
+    body_buffer.push(b'[');
+    for VisualizationInput {
+        dd_name,
+        function_names,
+        functions,
+        manager,
+        var_names,
+        vars,
+    } in inputs
+    {
+        write!(body_buffer, "{{\"type\":\"{}\",\"name\":\"", F::REPR_ID)?;
+        write!(JsonStrWriter(&mut body_buffer), "{dd_name}")?;
+        body_buffer.extend_from_slice(b"\",\"diagram\":\"");
+        crate::dddmp::export(
+            JsonStrWriter(&mut body_buffer),
+            manager,
+            true,
+            dd_name,
+            vars,
+            var_names,
+            functions,
+            function_names,
+            |_| false,
+        )?;
+        body_buffer.extend_from_slice(b"\"},");
+    }
+    body_buffer.pop(); // trailing ','
+    body_buffer.push(b']');
+
+    let listener = TcpListener::bind(("localhost", port))?;
+    println!("Data can be read on http://localhost:{port}");
+
+    for stream in listener.incoming() {
+        let mut stream = stream?;
+
+        let req_line = {
+            let mut stream = io::BufReader::new(&mut stream);
+            let mut buffer = String::new();
+            stream.read_line(&mut buffer)?;
+            buffer
+        };
+
+        // Basic routing: only handle GET /diagrams
+        if req_line.starts_with("GET /diagrams ") {
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\n\
+                Content-Type: application/json\r\n\
+                Access-Control-Allow-Origin: *\r\n\
+                Content-Length: {}\r\n\
+                \r\n",
+                body_buffer.len(),
+            )?;
+            stream.write_all(&body_buffer)?;
+            break;
+        }
+
+        stream.write_all(b"HTTP/1.1 404 NOT FOUND\r\n\r\nNot Found")?;
+    }
+
+    println!("Visualization has been sent!");
+    Ok(())
+}
+
+/// Input for the visualization
+pub struct VisualizationInput<'a, 'id, F: Function> {
+    /// The manager that the functions are from
+    pub manager: &'a F::Manager<'id>,
+    /// The name of the diagram
+    pub dd_name: &'a str,
+    /// The variables of the diagram
+    pub vars: &'a [&'a F],
+    /// The variable names
+    pub var_names: Option<&'a [&'a str]>,
+    /// The functions to visualize
+    pub functions: &'a [&'a F],
+    /// The names of the functions to visualize
+    pub function_names: Option<&'a [&'a str]>,
+}
+
+struct JsonStrWriter<'a>(&'a mut Vec<u8>);
+
+impl std::io::Write for JsonStrWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        for &c in buf {
+            match c {
+                0x08 => self.0.extend_from_slice(b"\\b"),
+                b'\t' => self.0.extend_from_slice(b"\\t"),
+                b'\n' => self.0.extend_from_slice(b"\\n"),
+                0x0c => self.0.extend_from_slice(b"\\ff"),
+                b'\r' => self.0.extend_from_slice(b"\\r"),
+                b'\\' => self.0.extend_from_slice(b"\\\\"),
+                b'"' => self.0.extend_from_slice(b"\\\""),
+                _ if c < 0x20 => write!(self.0, "\\u{c:04x}")?,
+                0x7f => self.0.extend_from_slice(b"\\u007f"), // ASCII DEL
+                _ => self.0.push(c),
+            }
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/oxidd-manager-index/src/manager.rs
+++ b/crates/oxidd-manager-index/src/manager.rs
@@ -2262,6 +2262,8 @@ unsafe impl<
         const TERMINALS: usize,
     > oxidd_core::function::Function for Function<NC, ET, TMC, RC, MDC, TERMINALS>
 {
+    const REPR_ID: &str = "<none>";
+
     type Manager<'id> = M<'id, NC, ET, TMC, RC, MDC, TERMINALS>;
 
     type ManagerRef = ManagerRef<NC, ET, TMC, RC, MDC, TERMINALS>;

--- a/crates/oxidd-manager-pointer/src/manager.rs
+++ b/crates/oxidd-manager-pointer/src/manager.rs
@@ -2017,6 +2017,8 @@ unsafe impl<
         const TAG_BITS: u32,
     > oxidd_core::function::Function for Function<NC, ET, TMC, RC, MDC, PAGE_SIZE, TAG_BITS>
 {
+    const REPR_ID: &str = "<none>";
+
     type Manager<'id> =
         Manager<'id, NC::T<'id>, ET, TMC::T<'id>, RC::T<'id>, MDC::T<'id>, PAGE_SIZE, TAG_BITS>;
 

--- a/crates/oxidd-rules-bdd/Cargo.toml
+++ b/crates/oxidd-rules-bdd/Cargo.toml
@@ -16,7 +16,7 @@ oxidd-core.workspace = true
 oxidd-derive.workspace = true
 
 # for implementing `DotStyle`
-oxidd-dump = { workspace = true, features = ["dddmp", "dot"] }
+oxidd-dump.workspace = true
 
 # bit vectors for memory efficient valuations
 bitvec = "1"

--- a/crates/oxidd-rules-bdd/src/complement_edge/apply_rec.rs
+++ b/crates/oxidd-rules-bdd/src/complement_edge/apply_rec.rs
@@ -965,6 +965,7 @@ impl<M: Manager + HasApplyCache<M, BCDDOp>> HasBCDDOpApplyCache<M> for M {}
 
 /// Boolean function backed by a complement edge binary decision diagram
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Function, Debug)]
+#[repr_id = "BCDD"]
 #[repr(transparent)]
 pub struct BCDDFunction<F: Function>(F);
 
@@ -1524,6 +1525,7 @@ pub mod mt {
 
     /// Boolean function backed by a complement edge binary decision diagram
     #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Function, Debug)]
+    #[repr_id = "BCDD"]
     #[repr(transparent)]
     pub struct BCDDFunctionMT<F: Function>(F);
 

--- a/crates/oxidd-rules-bdd/src/complement_edge/mod.rs
+++ b/crates/oxidd-rules-bdd/src/complement_edge/mod.rs
@@ -8,7 +8,6 @@ use std::marker::PhantomData;
 use oxidd_core::util::{AllocResult, Borrowed, EdgeDropGuard};
 use oxidd_core::{DiagramRules, Edge, HasLevel, InnerNode, LevelNo, Manager, Node, ReducedOrNew};
 use oxidd_derive::Countable;
-use oxidd_dump::dddmp::AsciiDisplay;
 
 use crate::stat;
 
@@ -249,7 +248,7 @@ impl std::str::FromStr for BCDDTerminal {
     }
 }
 
-impl AsciiDisplay for BCDDTerminal {
+impl oxidd_dump::AsciiDisplay for BCDDTerminal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         f.write_str("T")
     }

--- a/crates/oxidd-rules-bdd/src/simple/apply_rec.rs
+++ b/crates/oxidd-rules-bdd/src/simple/apply_rec.rs
@@ -778,6 +778,7 @@ impl<M: Manager + HasApplyCache<M, BDDOp>> HasBDDOpApplyCache<M> for M {}
 
 /// Boolean function backed by a binary decision diagram
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Function, Debug)]
+#[repr_id = "BDD"]
 #[repr(transparent)]
 pub struct BDDFunction<F: Function>(F);
 
@@ -1275,6 +1276,7 @@ pub mod mt {
     /// Boolean function backed by a binary decision diagram, multi-threaded
     /// version
     #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Function, Debug)]
+    #[repr_id = "BCDD"]
     #[repr(transparent)]
     pub struct BDDFunctionMT<F: Function>(F);
 

--- a/crates/oxidd-rules-bdd/src/simple/mod.rs
+++ b/crates/oxidd-rules-bdd/src/simple/mod.rs
@@ -7,7 +7,6 @@ use std::hash::Hash;
 use oxidd_core::util::{AllocResult, Borrowed};
 use oxidd_core::{DiagramRules, Edge, HasLevel, InnerNode, LevelNo, Manager, Node, ReducedOrNew};
 use oxidd_derive::Countable;
-use oxidd_dump::dddmp::AsciiDisplay;
 
 use crate::stat;
 
@@ -114,7 +113,7 @@ impl std::str::FromStr for BDDTerminal {
     }
 }
 
-impl AsciiDisplay for BDDTerminal {
+impl oxidd_dump::AsciiDisplay for BDDTerminal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             BDDTerminal::False => f.write_str("F"),

--- a/crates/oxidd-rules-mtbdd/Cargo.toml
+++ b/crates/oxidd-rules-mtbdd/Cargo.toml
@@ -16,7 +16,7 @@ oxidd-core.workspace = true
 oxidd-derive.workspace = true
 
 # For implementing `DotStyle`
-oxidd-dump = { workspace = true, features = ["dddmp", "dot"] }
+oxidd-dump.workspace = true
 
 # document feature flags
 document-features = "0.2"

--- a/crates/oxidd-rules-mtbdd/src/apply_rec.rs
+++ b/crates/oxidd-rules-mtbdd/src/apply_rec.rs
@@ -80,6 +80,7 @@ impl<M: Manager + HasApplyCache<M, MTBDDOp>> HasMTBDDOpApplyCache<M> for M {}
 
 /// Boolean function backed by a binary decision diagram
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Function, Debug)]
+#[repr_id = "MTBDD"]
 #[repr(transparent)]
 pub struct MTBDDFunction<F: Function>(F);
 

--- a/crates/oxidd-rules-mtbdd/src/terminal/int64.rs
+++ b/crates/oxidd-rules-mtbdd/src/terminal/int64.rs
@@ -5,7 +5,6 @@ use std::ops::{Add, Div, Mul, Sub};
 use std::str::FromStr;
 
 use oxidd_core::function::NumberBase;
-use oxidd_dump::dddmp::AsciiDisplay;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Int64 {
@@ -94,7 +93,7 @@ impl Display for Int64 {
     }
 }
 
-impl AsciiDisplay for Int64 {
+impl oxidd_dump::AsciiDisplay for Int64 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Int64::NaN => f.write_str("NaN"),

--- a/crates/oxidd-rules-tdd/Cargo.toml
+++ b/crates/oxidd-rules-tdd/Cargo.toml
@@ -16,7 +16,7 @@ oxidd-core.workspace = true
 oxidd-derive.workspace = true
 
 # For implementing `DotStyle`
-oxidd-dump = { workspace = true, features = ["dddmp", "dot"] }
+oxidd-dump.workspace = true
 
 # document feature flags
 document-features = "0.2"

--- a/crates/oxidd-rules-tdd/src/apply_rec.rs
+++ b/crates/oxidd-rules-tdd/src/apply_rec.rs
@@ -253,6 +253,7 @@ impl<M: Manager + HasApplyCache<M, TDDOp>> HasTDDOpApplyCache<M> for M {}
 
 /// Three value logic function backed by a ternary decision diagram
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Function, Debug)]
+#[repr_id = "TDD"]
 #[repr(transparent)]
 pub struct TDDFunction<F: Function>(F);
 

--- a/crates/oxidd-rules-tdd/src/lib.rs
+++ b/crates/oxidd-rules-tdd/src/lib.rs
@@ -13,7 +13,6 @@ use std::hash::Hash;
 use oxidd_core::util::{AllocResult, Borrowed};
 use oxidd_core::{DiagramRules, Edge, InnerNode, LevelNo, Manager, Node, ReducedOrNew};
 use oxidd_derive::Countable;
-use oxidd_dump::dddmp::AsciiDisplay;
 
 mod apply_rec;
 
@@ -117,7 +116,7 @@ impl std::str::FromStr for TDDTerminal {
     }
 }
 
-impl AsciiDisplay for TDDTerminal {
+impl oxidd_dump::AsciiDisplay for TDDTerminal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             TDDTerminal::False => f.write_str("F"),

--- a/crates/oxidd-rules-zbdd/Cargo.toml
+++ b/crates/oxidd-rules-zbdd/Cargo.toml
@@ -16,7 +16,7 @@ oxidd-core.workspace = true
 oxidd-derive.workspace = true
 
 # for implementing `DotStyle`
-oxidd-dump = { workspace = true, features = ["dddmp", "dot"] }
+oxidd-dump.workspace = true
 
 # bit vectors for memory efficient valuations
 bitvec = "1"

--- a/crates/oxidd-rules-zbdd/src/apply_rec.rs
+++ b/crates/oxidd-rules-zbdd/src/apply_rec.rs
@@ -531,6 +531,7 @@ trait HasZBDDOpApplyCache<M: Manager>: HasApplyCache<M, ZBDDOp> {}
 impl<M: Manager + HasApplyCache<M, ZBDDOp>> HasZBDDOpApplyCache<M> for M {}
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Function, Debug)]
+#[repr_id = "ZBDD"]
 #[repr(transparent)]
 pub struct ZBDDFunction<F: Function>(F);
 
@@ -1044,6 +1045,7 @@ pub mod mt {
     use super::*;
 
     #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Function, Debug)]
+    #[repr_id = "ZBDD"]
     #[repr(transparent)]
     pub struct ZBDDFunctionMT<F: Function>(F);
 

--- a/crates/oxidd-rules-zbdd/src/lib.rs
+++ b/crates/oxidd-rules-zbdd/src/lib.rs
@@ -15,7 +15,6 @@ use oxidd_core::{
     DiagramRules, Edge, HasLevel, InnerNode, LevelNo, LevelView, Manager, ReducedOrNew,
 };
 use oxidd_derive::Countable;
-use oxidd_dump::dddmp::AsciiDisplay;
 
 // spell-checker:ignore symm
 
@@ -133,7 +132,7 @@ impl std::str::FromStr for ZBDDTerminal {
     }
 }
 
-impl AsciiDisplay for ZBDDTerminal {
+impl oxidd_dump::AsciiDisplay for ZBDDTerminal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             ZBDDTerminal::Empty => f.write_str("E"),

--- a/crates/oxidd/Cargo.toml
+++ b/crates/oxidd/Cargo.toml
@@ -49,6 +49,7 @@ default = [
   "apply-cache-direct-mapped",
   "dddmp",
   "dot-export",
+  "visualize",
 ]
 
 ## Enable the simple BDD implementation
@@ -107,6 +108,9 @@ dddmp = ["oxidd-dump/dddmp"]
 ## Visualization using Graphviz DOT
 dot-export = ["oxidd-dump/dot"]
 
+## Visualization using OxiDD-viz
+visualize = ["oxidd-dump/visualize"]
+
 
 [[example]]
 name = "tdd"
@@ -114,7 +118,7 @@ required-features = ["tdd", "dot-export"]
 
 [[example]]
 name = "mtbdd"
-required-features = ["mtbdd", "dot-export"]
+required-features = ["mtbdd", "dot-export", "visualize"]
 
 [[example]]
 name = "zbdd"

--- a/crates/oxidd/Cargo.toml
+++ b/crates/oxidd/Cargo.toml
@@ -47,6 +47,8 @@ default = [
   "zbdd",
   "multi-threading",
   "apply-cache-direct-mapped",
+  "dddmp",
+  "dot-export",
 ]
 
 ## Enable the simple BDD implementation
@@ -99,14 +101,21 @@ statistics = [
   "oxidd-manager-index?/statistics",
 ]
 
+## DDDMP export
+dddmp = ["oxidd-dump/dddmp"]
+
+## Visualization using Graphviz DOT
+dot-export = ["oxidd-dump/dot"]
+
+
 [[example]]
 name = "tdd"
-required-features = ["tdd"]
+required-features = ["tdd", "dot-export"]
 
 [[example]]
 name = "mtbdd"
-required-features = ["mtbdd"]
+required-features = ["mtbdd", "dot-export"]
 
 [[example]]
 name = "zbdd"
-required-features = ["zbdd"]
+required-features = ["zbdd", "dot-export"]


### PR DESCRIPTION
Added a visualize function that can be used to send the diagram to the visualization tool.
This function does not really have any inherent visualization code, instead it just allows other programs running on the same machine to read this data (by polling), therefor we might want to consider renaming the function to something more generic. 
See the mtbdd example for usage. 