### PR TITLE
MTBDD: Implement recursive if-then-else operator and associated tests

### DIFF
--- a/crates/oxidd-core/src/function.rs
+++ b/crates/oxidd-core/src/function.rs
@@ -1484,6 +1484,50 @@ pub trait PseudoBooleanFunction: Function {
         })
     }
 
+    /// Compute `if self { then_case } else { else_case }` point-wise
+    ///
+    /// `self` must be a 0-1-valued function, i.e., every terminal reachable
+    /// from `self` must be [`Self::Number::zero()`][NumberBase::zero] or
+    /// [`Self::Number::one()`][NumberBase::one]. `then_case` and `else_case`
+    /// may be arbitrary-valued. Violating this precondition yields an
+    /// unspecified (but not unsafe) value; implementations may debug-assert
+    /// it instead.
+    ///
+    /// Locking behavior: acquires a shared manager lock
+    ///
+    /// Panics if `self`, `then_case`, and `else_case` don't belong to the
+    /// same manager.
+    fn ite(&self, then_case: &Self, else_case: &Self) -> AllocResult<Self> {
+        self.with_manager_shared(|manager, if_edge| {
+            let then_edge = then_case.as_edge(manager);
+            let else_edge = else_case.as_edge(manager);
+            let res = Self::ite_edge(manager, if_edge, then_edge, else_edge)?;
+            Ok(Self::from_edge(manager, res))
+        })
+    }
+
+    /// Edge version of [`Self::ite()`]
+    ///
+    /// The default implementation computes `else_edge * (1 - if_edge) +
+    /// if_edge * then_edge` using [`Self::add_edge()`], [`Self::sub_edge()`],
+    /// and [`Self::mul_edge()`]. Implementations backed by a decision diagram
+    /// where terminals are single-pass reachable should override this with a
+    /// dedicated recursive traversal, which avoids materializing the
+    /// intermediate results of the four generic applies above.
+    #[must_use]
+    fn ite_edge<'id>(
+        manager: &Self::Manager<'id>,
+        if_edge: &EdgeOfFunc<'id, Self>,
+        then_edge: &EdgeOfFunc<'id, Self>,
+        else_edge: &EdgeOfFunc<'id, Self>,
+    ) -> AllocResult<EdgeOfFunc<'id, Self>> {
+        let one = EdgeDropGuard::new(manager, Self::constant_edge(manager, Self::Number::one())?);
+        let not_if = EdgeDropGuard::new(manager, Self::sub_edge(manager, &one, if_edge)?);
+        let else_part = EdgeDropGuard::new(manager, Self::mul_edge(manager, else_edge, &not_if)?);
+        let then_part = EdgeDropGuard::new(manager, Self::mul_edge(manager, if_edge, then_edge)?);
+        Self::add_edge(manager, &then_part, &else_part)
+    }
+
     /// Edge version of [`Self::constant()`]
     fn constant_edge<'id>(
         manager: &Self::Manager<'id>,

--- a/crates/oxidd-derive/src/function.rs
+++ b/crates/oxidd-derive/src/function.rs
@@ -753,6 +753,7 @@ pub fn derive_pseudo_boolean_function(input: syn::DeriveInput) -> TokenStream {
             Binary("div"),
             Binary("min"),
             Binary("max"),
+            Ternary("ite"),
         ],
         |ctx| {
             let CustomMethodsCtx {

--- a/crates/oxidd-rules-mtbdd/src/apply_rec.rs
+++ b/crates/oxidd-rules-mtbdd/src/apply_rec.rs
@@ -76,6 +76,95 @@ where
     Ok(h)
 }
 
+/// Recursively apply the if-then-else operator (`if f { g } else { h }`)
+///
+/// `f` must be a 0-1-valued MTBDD (see [`PseudoBooleanFunction::ite_edge`]).
+/// As an extension of the classical restriction, terminals of `f` other than
+/// `0`, `1`, and NaN are treated as "truthy" (`debug_assert`-ed against,
+/// since this indicates a violation of the documented precondition), and NaN
+/// propagates like in the other operators of this module.
+fn apply_ite<M, T>(
+    manager: &M,
+    f: Borrowed<M::Edge>,
+    g: Borrowed<M::Edge>,
+    h: Borrowed<M::Edge>,
+) -> AllocResult<M::Edge>
+where
+    M: Manager<Terminal = T> + HasApplyCache<M, MTBDDOp>,
+    M::InnerNode: HasLevel,
+    T: NumberBase,
+{
+    stat!(call MTBDDOp::Ite);
+
+    // The condition is irrelevant if both branches agree.
+    if g == h {
+        return Ok(manager.clone_edge(&g));
+    }
+
+    // Terminal cases for `f`. We decide as soon as `f` resolves to a
+    // terminal, which is what makes this a 0-1-valued-condition restricted
+    // "ite", as opposed to a fully generic ternary operator.
+    if let Node::Terminal(t) = manager.get_node(&f) {
+        let t = t.borrow();
+        return Ok(if t.is_zero() {
+            manager.clone_edge(&h)
+        } else if t.is_nan() {
+            manager.get_terminal(T::nan())?
+        } else {
+            debug_assert!(t.is_one(), "the condition of `ite` must be 0-1-valued");
+            manager.clone_edge(&g)
+        });
+    }
+
+    // Query apply cache
+    stat!(cache_query MTBDDOp::Ite);
+    if let Some(res) = manager.apply_cache().get(
+        manager,
+        MTBDDOp::Ite,
+        &[f.borrowed(), g.borrowed(), h.borrowed()],
+    ) {
+        stat!(cache_hit MTBDDOp::Ite);
+        return Ok(res);
+    }
+
+    // `f` is not a terminal (handled above), so it is safe to unwrap it.
+    let fnode = manager.get_node(&f).unwrap_inner();
+    let gnode = manager.get_node(&g);
+    let hnode = manager.get_node(&h);
+    let flevel = fnode.level();
+    let glevel = gnode.level();
+    let hlevel = hnode.level();
+    let level = flevel.min(glevel).min(hlevel);
+
+    // Collect cofactors of all top-most nodes
+    let (ft, fe) = if flevel == level {
+        collect_children(fnode)
+    } else {
+        (f.borrowed(), f.borrowed())
+    };
+    let (gt, ge) = if glevel == level {
+        collect_children(gnode.unwrap_inner())
+    } else {
+        (g.borrowed(), g.borrowed())
+    };
+    let (ht, he) = if hlevel == level {
+        collect_children(hnode.unwrap_inner())
+    } else {
+        (h.borrowed(), h.borrowed())
+    };
+
+    let t = EdgeDropGuard::new(manager, apply_ite(manager, ft, gt, ht)?);
+    let e = EdgeDropGuard::new(manager, apply_ite(manager, fe, ge, he)?);
+    let res = reduce(manager, level, t.into_edge(), e.into_edge(), MTBDDOp::Ite)?;
+
+    // Add to apply cache
+    manager
+        .apply_cache()
+        .add(manager, MTBDDOp::Ite, &[f, g, h], res.borrowed());
+
+    Ok(res)
+}
+
 // --- Function Interface ------------------------------------------------------
 
 /// Workaround for https://github.com/rust-lang/rust/issues/49601
@@ -184,6 +273,21 @@ where
         rhs: &EdgeOfFunc<'id, Self>,
     ) -> AllocResult<EdgeOfFunc<'id, Self>> {
         apply_bin::<_, T, { MTBDDOp::Max as u8 }>(manager, lhs.borrowed(), rhs.borrowed())
+    }
+
+    #[inline]
+    fn ite_edge<'id>(
+        manager: &Self::Manager<'id>,
+        if_edge: &EdgeOfFunc<'id, Self>,
+        then_edge: &EdgeOfFunc<'id, Self>,
+        else_edge: &EdgeOfFunc<'id, Self>,
+    ) -> AllocResult<EdgeOfFunc<'id, Self>> {
+        apply_ite::<_, T>(
+            manager,
+            if_edge.borrowed(),
+            then_edge.borrowed(),
+            else_edge.borrowed(),
+        )
     }
 
     #[inline]

--- a/crates/oxidd/tests/pseudo_boolean_function.rs
+++ b/crates/oxidd/tests/pseudo_boolean_function.rs
@@ -1,0 +1,231 @@
+//! Tests for `PseudoBooleanFunction` implementations
+
+#![cfg_attr(miri, allow(unused))]
+
+use oxidd::mtbdd::terminal::I64;
+use oxidd::mtbdd::MTBDDFunction;
+use oxidd::{Function, Manager, ManagerRef, NumberBase, PseudoBooleanFunction, VarNo};
+
+// spell-checker:ignore nvars
+
+const NUM_VARS: VarNo = 3;
+
+/// The "textbook" definition of `ite` in terms of the other arithmetic
+/// operators, i.e., the workaround that [`PseudoBooleanFunction::ite_edge()`]
+/// obsoletes for implementations providing a dedicated single-pass
+/// implementation.
+fn naive_ite<'id>(
+    manager: &<MTBDDFunction<I64> as Function>::Manager<'id>,
+    f: &MTBDDFunction<I64>,
+    g: &MTBDDFunction<I64>,
+    h: &MTBDDFunction<I64>,
+) -> MTBDDFunction<I64> {
+    let one = MTBDDFunction::constant(manager, I64::Num(1)).unwrap();
+    let keep_h = one.sub(f).unwrap();
+    h.mul(&keep_h).unwrap().add(&f.mul(g).unwrap()).unwrap()
+}
+
+/// Evaluate `fun` at every one of the `2^NUM_VARS` valuations and return the
+/// results in a canonical order (`i`-th bit of the index selects variable
+/// `i`).
+fn eval_all(fun: &MTBDDFunction<I64>) -> Vec<I64> {
+    (0..(1u32 << NUM_VARS))
+        .map(|assignment| {
+            fun.eval((0..NUM_VARS).map(|v| (v, (assignment >> v) & 1 != 0)))
+        })
+        .collect()
+}
+
+fn setup() -> (
+    oxidd::mtbdd::MTBDDManagerRef<I64>,
+    Vec<MTBDDFunction<I64>>,
+) {
+    let mref = oxidd::mtbdd::new_manager(1024, 1024, 1024, 1);
+    let vars = mref
+        .with_manager_exclusive(|manager| {
+            manager
+                .add_named_vars((0..NUM_VARS).map(|i| format!("x{i}")))
+                .unwrap();
+            (0..NUM_VARS)
+                .map(|i| MTBDDFunction::var(manager, i))
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .unwrap();
+    (mref, vars)
+}
+
+#[test]
+fn ite_matches_naive_definition() {
+    let (mref, vars) = setup();
+    mref.with_manager_shared(|manager| {
+        let c = |v: i64| MTBDDFunction::constant(manager, I64::Num(v)).unwrap();
+
+        // A representative set of 0-1-valued conditions (constants and
+        // variable-based indicators, combined via arithmetic so that the
+        // result stays within {0, 1}).
+        let conditions = vec![
+            c(0),
+            c(1),
+            vars[0].clone(),
+            // x0 * x1 == x0 AND x1
+            vars[0].mul(&vars[1]).unwrap(),
+            // x0 + x1 - x0*x1 == x0 OR x1
+            vars[0]
+                .add(&vars[1])
+                .unwrap()
+                .sub(&vars[0].mul(&vars[1]).unwrap())
+                .unwrap(),
+        ];
+
+        // Note: NaN/±∞ branches are deliberately excluded here. The naive
+        // arithmetic definition evaluates *both* branches and combines them
+        // via `0 * x`, which is not the identity in this semiring for NaN or
+        // ±∞ (e.g. `0 * PlusInf == PlusInf`, see `I64`'s `Mul` impl) — so it
+        // would incorrectly "leak" the untaken branch's value. The real
+        // `ite` never evaluates the untaken branch at all; see
+        // `ite_ignores_untaken_branch_value` below for that distinction.
+        let branches = vec![
+            c(0),
+            c(1),
+            c(-7),
+            c(42),
+            vars[1].clone(),
+            vars[2].clone(),
+            vars[0].add(&vars[2]).unwrap(),
+        ];
+
+        for f in &conditions {
+            for g in &branches {
+                for h in &branches {
+                    let fast = f.ite(g, h).unwrap();
+                    let naive = naive_ite(manager, f, g, h);
+                    assert_eq!(
+                        eval_all(&fast),
+                        eval_all(&naive),
+                        "ite mismatch for f={:?}, g={:?}, h={:?}",
+                        eval_all(f),
+                        eval_all(g),
+                        eval_all(h)
+                    );
+                }
+            }
+        }
+    });
+}
+
+#[test]
+fn ite_short_circuits_equal_branches() {
+    let (mref, vars) = setup();
+    mref.with_manager_shared(|manager| {
+        let g = vars[0].add(&vars[1]).unwrap();
+        let h = g.clone();
+        // Even a condition containing NaN must not disturb the result, since
+        // both branches agree unconditionally.
+        let f = MTBDDFunction::constant(manager, I64::NaN).unwrap();
+        let res = f.ite(&g, &h).unwrap();
+        assert!(res == g, "expected the g branch's edge to be reused as-is");
+    });
+}
+
+#[test]
+fn ite_constant_condition() {
+    let (mref, vars) = setup();
+    mref.with_manager_shared(|manager| {
+        let g = vars[0].clone();
+        let h = vars[1].clone();
+        let tt = MTBDDFunction::constant(manager, I64::Num(1)).unwrap();
+        let ff = MTBDDFunction::constant(manager, I64::Num(0)).unwrap();
+
+        assert!(tt.ite(&g, &h).unwrap() == g);
+        assert!(ff.ite(&g, &h).unwrap() == h);
+    });
+}
+
+#[test]
+fn ite_condition_nan_propagates() {
+    let (mref, vars) = setup();
+    mref.with_manager_shared(|manager| {
+        let g = vars[0].clone();
+        let h = vars[1].clone();
+        let nan = MTBDDFunction::constant(manager, I64::NaN).unwrap();
+        let res = nan.ite(&g, &h).unwrap();
+        for v in eval_all(&res) {
+            assert!(v.is_nan(), "expected NaN, got {v:?}");
+        }
+    });
+}
+
+#[test]
+fn ite_ignores_untaken_branch_value() {
+    // Unlike the naive `h*(1-f) + f*g` definition, a real `ite` never
+    // evaluates the untaken branch, so a non-finite value there (NaN, or an
+    // infinity that would "leak" through `0 * x` in this semiring) must not
+    // affect the result. `f` is a variable here (not a constant), so this
+    // also exercises the recursive case, not just the terminal shortcuts.
+    let (mref, vars) = setup();
+    mref.with_manager_shared(|manager| {
+        let good = vars[1].clone();
+        for bad_value in [I64::NaN, I64::PlusInf, I64::MinusInf] {
+            let bad = MTBDDFunction::constant(manager, bad_value).unwrap();
+
+            // x0=1 selects `good`, `bad` is untaken.
+            let res = vars[0].ite(&good, &bad).unwrap();
+            assert_eq!(
+                res.eval([(0, true), (1, true)]),
+                good.eval([(0, true), (1, true)])
+            );
+            assert_eq!(
+                res.eval([(0, true), (1, false)]),
+                good.eval([(0, true), (1, false)])
+            );
+
+            // x0=0 selects `good`, `bad` is untaken.
+            let res = vars[0].ite(&bad, &good).unwrap();
+            assert_eq!(
+                res.eval([(0, false), (1, true)]),
+                good.eval([(0, false), (1, true)])
+            );
+        }
+    });
+}
+
+#[test]
+fn ite_overwrite_use_case() {
+    // Mirrors the classical "overwrite a single leaf" use case: given a
+    // 0-1-valued `indicator` selecting exactly one path, `ite(indicator,
+    // value, seen)` keeps `seen` everywhere else and replaces the value
+    // reached by `indicator`'s cube.
+    let (mref, vars) = setup();
+    mref.with_manager_shared(|manager| {
+        let seen = vars[0]
+            .add(&vars[1])
+            .unwrap()
+            .add(&vars[2])
+            .unwrap();
+
+        // Indicator of the cube x0=1, x1=0, x2=1.
+        let not_x1 = MTBDDFunction::constant(manager, I64::Num(1))
+            .unwrap()
+            .sub(&vars[1])
+            .unwrap();
+        let indicator = vars[0].mul(&not_x1).unwrap().mul(&vars[2]).unwrap();
+
+        let value = MTBDDFunction::constant(manager, I64::Num(100)).unwrap();
+        let overwritten = indicator.ite(&value, &seen).unwrap();
+        let naive = naive_ite(manager, &indicator, &value, &seen);
+        assert_eq!(eval_all(&overwritten), eval_all(&naive));
+
+        for assignment in 0..(1u32 << NUM_VARS) {
+            let args = (0..NUM_VARS)
+                .map(|v| (v, (assignment >> v) & 1 != 0))
+                .collect::<Vec<_>>();
+            let got = overwritten.eval(args.iter().copied());
+            let expect = if assignment & 0b111 == 0b101 {
+                I64::Num(100)
+            } else {
+                seen.eval(args.iter().copied())
+            };
+            assert_eq!(got, expect, "mismatch at assignment {assignment:#05b}");
+        }
+    });
+}


### PR DESCRIPTION
This PR implements `MTBDDOp::Ite`, which previously existed as an unused enum variant with no algorithm behind it.

`ite(f, g, h)` ("if f then g else h") is the classical 0-1-valued-condition ADD if-then-else from [Bahar et al.'s ADD paper](https://www.semanticscholar.org/paper/Algebric-Decision-Diagrams-and-Their-Applications-Bahar-Frohm/40dfa8b6338fa5913cad5732dcfa1937f0989242), generalized to MTBDD. It's needed for single-pass "overwrite the value at exactly the leaf a given cube reaches" operations, which today can only be expressed as `self * (1 - indicator) + indicator * value` — three multiplications and an addition, each a full generic apply over the diagram, churning intermediate nodes that GC then has to clean up.

This mirrors the architecture already used for `BooleanFunction::ite/ite_edge` in `oxidd-rules-bdd`: a default, generically-correct (but slower) implementation lives on the trait, and `oxidd-rules-mtbdd` overrides it with a dedicated single-pass recursive traversal.

**Changes**

- `oxidd-core`: added `ite`/`ite_edge` to `PseudoBooleanFunction`. The default `ite_edge` is exactly the arithmetic identity above, expressed via `add_edge`/`sub_edge`/`mul_edge`, so any implementor gets correct (if unoptimized) behavior for free.
- `oxidd-derive`: added `Ternary("ite")` to the `PseudoBooleanFunction` derive so the outer, index/pointer-backed `MTBDDFunction<T>` forwards `ite`/`ite_edge` to the underlying implementation rather than resolving to the (slower) trait default.
- `oxidd-rules-mtbdd`: implemented `apply_ite`, a recursive ternary apply over `(f, g, h)` using the apply cache slot that was already sized for 3 operands. Short-circuits: `g == h` returns that branch unconditionally; a terminal `f` of 1/0 returns `g/h`; a terminal `f` of `NaN` propagates `NaN` (consistent with the other operators in this module). `f` is documented to be 0-1-valued; any other terminal is a precondition violation caught by `debug_assert!` in debug builds, and treated as "truthy" in release so it never panics on untrusted input.
- Tests (`oxidd/tests/pseudo_boolean_function.rs`): checks `ite` against the naive arithmetic definition across constants and variable-based conditions, the `g == h` short-circuit, constant conditions, `NaN` propagation through the condition, and the "overwrite a single leaf" use case end-to-end.

One test (`ite_ignores_untaken_branch_value`) is worth calling out: it demonstrates that the new implementation is not just faster than the arithmetic workaround but more correct. The naive formula evaluates both branches and combines them via `0 * x`, which is not the identity in this semiring for `NaN` or ±∞ (`I64`'s `Mul` defines `0 * PlusInf == PlusInf`, for instance), so it can leak the untaken branch's value into the result. A real `ite` never evaluates the untaken branch at all.

**Testing performed (all green)**

- `cargo test --workspace`
- `cargo clippy --all-targets -- -D warnings` on the touched crates
- `cargo doc` to confirm the new intra-doc links resolve
