### PR TITLE
Implement restrict() for PseudoBooleanFunction/MTBDD

### DIFF
--- a/crates/oxidd-core/src/function.rs
+++ b/crates/oxidd-core/src/function.rs
@@ -1484,6 +1484,29 @@ pub trait PseudoBooleanFunction: Function {
         })
     }
 
+    /// Restrict a set of variables to constant values
+    ///
+    /// `vars` conceptually is a partial assignment, represented as the
+    /// conjunction of positive or negative literals (0-1-valued functions),
+    /// depending on whether the variable should be mapped to true or false.
+    /// With this representation, the result is equivalent to the multiplication
+    /// of `self` and `vars`, unless there are infinite or NaN values in the
+    /// image of `self`.
+    ///
+    /// In other words, the restriction is a point-wise Shannon cofactor with
+    /// respect to the partial assignment given by `vars`. In an MTBDD, the
+    /// result never has more nodes than `self`.
+    ///
+    /// Locking behavior: acquires the manager's lock for shared access.
+    ///
+    /// Panics if `self` and `vars` don't belong to the same manager.
+    fn restrict(&self, vars: &Self) -> AllocResult<Self> {
+        self.with_manager_shared(|manager, root| {
+            let e = Self::restrict_edge(manager, root, vars.as_edge(manager))?;
+            Ok(Self::from_edge(manager, e))
+        })
+    }
+
     /// Edge version of [`Self::constant()`]
     fn constant_edge<'id>(
         manager: &Self::Manager<'id>,
@@ -1536,6 +1559,14 @@ pub trait PseudoBooleanFunction: Function {
         manager: &Self::Manager<'id>,
         lhs: &EdgeOfFunc<'id, Self>,
         rhs: &EdgeOfFunc<'id, Self>,
+    ) -> AllocResult<EdgeOfFunc<'id, Self>>;
+
+    /// Edge version of [`Self::restrict()`]
+    #[must_use]
+    fn restrict_edge<'id>(
+        manager: &Self::Manager<'id>,
+        root: &EdgeOfFunc<'id, Self>,
+        vars: &EdgeOfFunc<'id, Self>,
     ) -> AllocResult<EdgeOfFunc<'id, Self>>;
 
     /// Evaluate this function

--- a/crates/oxidd-derive/src/function.rs
+++ b/crates/oxidd-derive/src/function.rs
@@ -753,6 +753,7 @@ pub fn derive_pseudo_boolean_function(input: syn::DeriveInput) -> TokenStream {
             Binary("div"),
             Binary("min"),
             Binary("max"),
+            Binary("restrict"),
         ],
         |ctx| {
             let CustomMethodsCtx {

--- a/crates/oxidd-rules-mtbdd/src/apply_rec.rs
+++ b/crates/oxidd-rules-mtbdd/src/apply_rec.rs
@@ -6,7 +6,9 @@ use fixedbitset::FixedBitSet;
 
 use oxidd_core::function::{EdgeOfFunc, Function, INodeOfFunc, NumberBase, PseudoBooleanFunction};
 use oxidd_core::util::{AllocResult, Borrowed, EdgeDropGuard};
-use oxidd_core::{ApplyCache, Edge, HasApplyCache, HasLevel, InnerNode, Manager, Node, Tag, VarNo};
+use oxidd_core::{
+    ApplyCache, Edge, HasApplyCache, HasLevel, InnerNode, LevelNo, Manager, Node, Tag, VarNo,
+};
 use oxidd_derive::Function;
 use oxidd_dump::dot::DotStyle;
 
@@ -14,7 +16,7 @@ use oxidd_dump::dot::DotStyle;
 use super::STAT_COUNTERS;
 use super::{MTBDDOp, Operation, collect_children, reduce, stat};
 
-// spell-checker:ignore fnode,gnode,flevel,glevel
+// spell-checker:ignore fnode,gnode,vnode,flevel,glevel,vlevel
 
 /// Recursively apply the binary operator `OP` to `f` and `g`
 ///
@@ -74,6 +76,156 @@ where
         .add(manager, operator, &[op1, op2], h.borrowed());
 
     Ok(h)
+}
+
+/// Result of [`restrict_inner()`]
+enum RestrictInnerResult<'a, M: Manager> {
+    Done(M::Edge),
+    Rec {
+        vars: Borrowed<'a, M::Edge>,
+        f: Borrowed<'a, M::Edge>,
+        fnode: &'a M::InnerNode,
+    },
+}
+
+/// Tail-recursive part of [`restrict()`]. `f` is the function of which the
+/// variables should be restricted to constant values according to `vars`.
+///
+/// Invariant: `f` points to `fnode` at `flevel`, `vars` points to `vnode`
+#[inline]
+fn restrict_inner<'a, M, T>(
+    manager: &'a M,
+    f: Borrowed<'a, M::Edge>,
+    fnode: &'a M::InnerNode,
+    flevel: LevelNo,
+    vars: Borrowed<'a, M::Edge>,
+    vnode: &'a M::InnerNode,
+) -> RestrictInnerResult<'a, M>
+where
+    M: Manager<Terminal = T>,
+    M::InnerNode: HasLevel,
+    T: NumberBase,
+{
+    debug_assert!(std::ptr::eq(manager.get_node(&f).unwrap_inner(), fnode));
+    debug_assert_eq!(fnode.level(), flevel);
+    debug_assert!(std::ptr::eq(manager.get_node(&vars).unwrap_inner(), vnode));
+
+    let vlevel = vnode.level();
+    if vlevel > flevel {
+        // f above vars
+        return RestrictInnerResult::Rec { vars, f, fnode };
+    }
+
+    let vt = vnode.child(0);
+    if vlevel < flevel {
+        // vars above f
+        return match manager.get_node(&vt) {
+            Node::Inner(n) => restrict_inner(manager, f, fnode, flevel, vt, n),
+            Node::Terminal(t) if t.borrow().is_one() => {
+                RestrictInnerResult::Done(manager.clone_edge(&f))
+            }
+            Node::Terminal(_) => {
+                let ve = vnode.child(1);
+                if let Node::Inner(n) = manager.get_node(&ve) {
+                    restrict_inner(manager, f, fnode, flevel, ve, n)
+                } else {
+                    RestrictInnerResult::Done(manager.clone_edge(&f))
+                }
+            }
+        };
+    }
+
+    debug_assert_eq!(vlevel, flevel);
+    // top var at the level of f ⇒ select accordingly
+    let (f, vars, vnode) = match manager.get_node(&vt) {
+        Node::Inner(n) => {
+            debug_assert!(
+                matches!(manager.get_node(&vnode.child(1)), Node::Terminal(t) if t.borrow().is_zero()),
+                "vars must be a conjunction of literals"
+            );
+            // positive literal ⇒ select then branch
+            (fnode.child(0), vt, n)
+        }
+        Node::Terminal(t) if t.borrow().is_one() => {
+            debug_assert!(
+                matches!(manager.get_node(&vnode.child(1)), Node::Terminal(t) if t.borrow().is_zero()),
+                "vars must be a conjunction of literals"
+            );
+            // positive literal ⇒ select then branch
+            return RestrictInnerResult::Done(manager.clone_edge(&fnode.child(0)));
+        }
+        Node::Terminal(_) => {
+            // negative literal ⇒ select else branch
+            let f = fnode.child(1);
+            let ve = vnode.child(1);
+            if let Node::Inner(n) = manager.get_node(&ve) {
+                (f, ve, n)
+            } else {
+                return RestrictInnerResult::Done(manager.clone_edge(&f));
+            }
+        }
+    };
+
+    if let Node::Inner(fnode) = manager.get_node(&f) {
+        restrict_inner(manager, f, fnode, fnode.level(), vars, vnode)
+    } else {
+        RestrictInnerResult::Done(manager.clone_edge(&f))
+    }
+}
+
+/// Recursively restrict a set of `vars` (a conjunction of literals) to
+/// constant values in `f`
+fn restrict<M, T>(
+    manager: &M,
+    f: Borrowed<M::Edge>,
+    vars: Borrowed<M::Edge>,
+) -> AllocResult<M::Edge>
+where
+    M: Manager<Terminal = T> + HasApplyCache<M, MTBDDOp>,
+    M::InnerNode: HasLevel,
+    T: NumberBase,
+{
+    stat!(call MTBDDOp::Restrict);
+
+    let (Node::Inner(fnode), Node::Inner(vnode)) = (manager.get_node(&f), manager.get_node(&vars))
+    else {
+        return Ok(manager.clone_edge(&f));
+    };
+
+    match restrict_inner(manager, f, fnode, fnode.level(), vars, vnode) {
+        RestrictInnerResult::Done(res) => Ok(res),
+        RestrictInnerResult::Rec { vars, f, fnode } => {
+            // f above top-most restrict variable
+
+            // Query apply cache
+            stat!(cache_query MTBDDOp::Restrict);
+            if let Some(res) = manager.apply_cache().get(
+                manager,
+                MTBDDOp::Restrict,
+                &[f.borrowed(), vars.borrowed()],
+            ) {
+                stat!(cache_hit MTBDDOp::Restrict);
+                return Ok(res);
+            }
+
+            let (ft, fe) = collect_children(fnode);
+            let t = EdgeDropGuard::new(manager, restrict(manager, ft, vars.borrowed())?);
+            let e = EdgeDropGuard::new(manager, restrict(manager, fe, vars.borrowed())?);
+            let res = reduce(
+                manager,
+                fnode.level(),
+                t.into_edge(),
+                e.into_edge(),
+                MTBDDOp::Restrict,
+            )?;
+
+            manager
+                .apply_cache()
+                .add(manager, MTBDDOp::Restrict, &[f, vars], res.borrowed());
+
+            Ok(res)
+        }
+    }
 }
 
 // --- Function Interface ------------------------------------------------------
@@ -184,6 +336,15 @@ where
         rhs: &EdgeOfFunc<'id, Self>,
     ) -> AllocResult<EdgeOfFunc<'id, Self>> {
         apply_bin::<_, T, { MTBDDOp::Max as u8 }>(manager, lhs.borrowed(), rhs.borrowed())
+    }
+
+    #[inline]
+    fn restrict_edge<'id>(
+        manager: &Self::Manager<'id>,
+        root: &EdgeOfFunc<'id, Self>,
+        vars: &EdgeOfFunc<'id, Self>,
+    ) -> AllocResult<EdgeOfFunc<'id, Self>> {
+        restrict::<_, T>(manager, root.borrowed(), vars.borrowed())
     }
 
     #[inline]

--- a/crates/oxidd-rules-mtbdd/src/lib.rs
+++ b/crates/oxidd-rules-mtbdd/src/lib.rs
@@ -89,6 +89,9 @@ pub enum MTBDDOp {
 
     /// If-then-else
     Ite,
+
+    /// Restrict a set of variables to constant values
+    Restrict,
 }
 
 /// Collect the two children of a binary node

--- a/crates/oxidd/tests/pseudo_boolean_function.rs
+++ b/crates/oxidd/tests/pseudo_boolean_function.rs
@@ -1,0 +1,156 @@
+//! Tests for `PseudoBooleanFunction` implementations
+
+use oxidd::mtbdd::MTBDDFunction;
+use oxidd::mtbdd::terminal::I64;
+use oxidd::util::AllocResult;
+use oxidd::{Function, Manager, ManagerRef, PseudoBooleanFunction, VarNo};
+
+// spell-checker:ignore mref
+
+const NUM_VARS: VarNo = 3;
+
+fn setup() -> (oxidd::mtbdd::MTBDDManagerRef<I64>, Vec<MTBDDFunction<I64>>) {
+    let mref = oxidd::mtbdd::new_manager(1024, 1024, 1024, 1);
+    let vars = mref
+        .with_manager_exclusive(|manager| {
+            manager
+                .add_named_vars((0..NUM_VARS).map(|i| format!("x{i}")))
+                .unwrap();
+            (0..NUM_VARS)
+                .map(|i| MTBDDFunction::var(manager, i))
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .unwrap();
+    (mref, vars)
+}
+
+/// A positive (`polarity == true`) or negative literal for `var`, encoded as
+/// a 0-1-valued `MTBDDFunction`.
+fn literal(
+    one: &MTBDDFunction<I64>,
+    var: &MTBDDFunction<I64>,
+    polarity: bool,
+) -> AllocResult<MTBDDFunction<I64>> {
+    if polarity {
+        Ok(var.clone())
+    } else {
+        one.sub(var)
+    }
+}
+
+/// The conjunction (cube) of `literal(one, vars[v], b)` for each `(v, b)` in
+/// `assignment`.
+fn cube(
+    one: &MTBDDFunction<I64>,
+    vars: &[MTBDDFunction<I64>],
+    assignment: &[(VarNo, bool)],
+) -> AllocResult<MTBDDFunction<I64>> {
+    let mut result = one.clone();
+    for &(v, b) in assignment {
+        result = result.mul(&literal(one, &vars[v as usize], b)?)?;
+    }
+    Ok(result)
+}
+
+/// `assignment` with the variables named in `fixed` overridden to their fixed
+/// values.
+fn apply_fixed(assignment: u32, fixed: &[(VarNo, bool)]) -> Vec<(VarNo, bool)> {
+    let mut bits: Vec<(VarNo, bool)> = (0..NUM_VARS)
+        .map(|v| (v, (assignment >> v) & 1 != 0))
+        .collect();
+    for &(v, b) in fixed {
+        bits[v as usize] = (v, b);
+    }
+    bits
+}
+
+#[test]
+fn restrict_matches_manual_cofactor() -> AllocResult<()> {
+    let (mref, vars) = setup();
+    mref.with_manager_shared(|manager| {
+        let one = MTBDDFunction::constant(manager, I64::Num(1))?;
+
+        let functions = vec![
+            vars[0].add(&vars[1])?.sub(&vars[2])?,
+            vars[0].mul(&vars[1])?.add(&vars[2])?,
+            vars[0].add(&vars[1])?.add(&vars[2])?,
+        ];
+
+        let fixed_sets: Vec<Vec<(VarNo, bool)>> = vec![
+            vec![],
+            vec![(0, true)],
+            vec![(0, false)],
+            vec![(1, true), (2, false)],
+            vec![(0, false), (1, true), (2, true)],
+        ];
+
+        for f in &functions {
+            for fixed in &fixed_sets {
+                let c = cube(&one, &vars, fixed)?;
+                let restricted = f.restrict(&c)?;
+
+                for assignment in 0..(1u32 << NUM_VARS) {
+                    let free_args = (0..NUM_VARS).map(|v| (v, (assignment >> v) & 1 != 0));
+                    let got = restricted.eval(free_args);
+                    let expect = f.eval(apply_fixed(assignment, fixed));
+                    assert_eq!(
+                        got, expect,
+                        "mismatch for fixed={fixed:?}, assignment={assignment:#05b}"
+                    );
+                }
+            }
+        }
+        Ok(())
+    })
+}
+
+#[test]
+fn restrict_by_true_cube_is_identity() -> AllocResult<()> {
+    let (mref, vars) = setup();
+    mref.with_manager_shared(|manager| {
+        let f = vars[0].add(&vars[1])?;
+        let empty_cube = MTBDDFunction::constant(manager, I64::Num(1))?;
+        assert!(f.restrict(&empty_cube)? == f);
+        Ok(())
+    })
+}
+
+#[test]
+fn restrict_of_constant_is_identity() -> AllocResult<()> {
+    let (mref, vars) = setup();
+    mref.with_manager_shared(|manager| {
+        let f = MTBDDFunction::constant(manager, I64::Num(42))?;
+        let one = MTBDDFunction::constant(manager, I64::Num(1))?;
+        let c = cube(&one, &vars, &[(0, true), (1, false)])?;
+        assert!(f.restrict(&c)? == f);
+        Ok(())
+    })
+}
+
+#[test]
+fn restrict_shrinks_node_count() -> AllocResult<()> {
+    let (mref, vars) = setup();
+    mref.with_manager_shared(|manager| {
+        let one = MTBDDFunction::constant(manager, I64::Num(1))?;
+        let f = vars[0].add(&vars[1])?.add(&vars[2])?;
+        let before = f.node_count();
+
+        let c = cube(&one, &vars, &[(0, true)])?;
+        let restricted = f.restrict(&c)?;
+        assert!(
+            restricted.node_count() < before,
+            "expected fewer nodes after fixing x0: before={before}, after={}",
+            restricted.node_count()
+        );
+
+        // Fixing all variables must yield a single terminal node.
+        let full = cube(&one, &vars, &[(0, true), (1, false), (2, true)])?;
+        let fully_restricted = f.restrict(&full)?;
+        assert_eq!(fully_restricted.node_count(), 1);
+
+        let expected_value = f.eval([(0, true), (1, false), (2, true)]);
+        let expected = MTBDDFunction::constant(manager, expected_value)?;
+        assert!(fully_restricted == expected);
+        Ok(())
+    })
+}


### PR DESCRIPTION
Implements `restrict()` for `PseudoBooleanFunction`/MTBDD: given a cube of literals (a conjunction of positive/negative variable assignments), fix those variables to their assigned constants and simplify. This mirrors `BooleanFunctionQuant::restrict`, which already exists for BDD/BCDD.

The algorithm is a direct port of BDD's `restrict`/`restrict_inner`: walk `f` and the `vars` cube in lockstep by level. Wherever `vars` doesn't mention `f`'s current top variable, pass through untouched and recurse into both children. Wherever it does, pick exactly the one child the literal's polarity demands and discard the other. The result is structurally never larger than `f`, and the traversal is linear.

Changes

- `oxidd-rules-mtbdd`: added the `MTBDDOp::Restrict` variant and implemented `restrict`/`restrict_inner`, adapting BDD's algorithm from `BDDTerminal::True`/`False` checks to `NumberBase::is_one()`/`is_zero()`. Wired up as the `restrict_edge` override on `MTBDDFunction`'s `PseudoBooleanFunction` impl.
- `oxidd-core`: added `restrict`/`restrict_edge` to `PseudoBooleanFunction`, mirroring `BooleanFunctionQuant::restrict`'s docs and shape. `restrict_edge` has no default body — there's no cheap arithmetic identity that expresses "pick a branch", so (matching BDD's own precedent) every implementor must provide it directly.
- `oxidd-derive`: added `Binary("restrict")` to the `PseudoBooleanFunction` derive list.
- Tests (`oxidd/tests/pseudo_boolean_function.rs`): an exhaustive oracle check — `restrict(f, cube).eval(a) == f.eval(a with the fixed variables overridden)` across several functions, several fixed-variable sets, and all 2^3 assignments — plus the empty-cube and constant-f identity cases, and a direct test that node_count() strictly decreases after fixing one variable, and fixing all variables collapses the diagram to a single terminal matching the expected value.

Testing

- `cargo test --workspace` (all green except the pre-existing, unrelated oxidd-ffi-python linker failure in my local environment)
- `cargo clippy --all-targets -- -D warnings` on the touched crates
- `cargo fmt` and `cargo doc clean`