### PR TITLE
Fix stale current_store address in LocalStoreStateGuard::drop

### DIFF
--- a/crates/oxidd-manager-index/src/manager.rs
+++ b/crates/oxidd-manager-index/src/manager.rs
@@ -881,12 +881,28 @@ where
         }
 
         LOCAL_STORE_STATE.with(|local| {
-            if addr(self.0) == local.current_store.get()
-                && (local.next_free.get() != 0
+            if addr(self.0) == local.current_store.get() {
+                if local.next_free.get() != 0
                     || local.initialized.get() % CHUNK_SIZE != 0
-                    || local.node_count_delta.get() != 0)
-            {
-                drop_slow(&self.0.inner_nodes.slots, &self.0.state, TERMINALS as u32);
+                    || local.node_count_delta.get() != 0
+                {
+                    drop_slow(&self.0.inner_nodes.slots, &self.0.state, TERMINALS as u32);
+                } else {
+                    // Nothing to flush, but ownership of the thread-local
+                    // fast path must still be released here regardless.
+                    // Leaving `current_store` pointing at this (about to be
+                    // dropped) `Store` is a real hazard: if a *different*
+                    // `Store` is later allocated at the same address (very
+                    // plausible for same-sized arenas reused from the
+                    // allocator after this one is freed), that new `Store`'s
+                    // `prepare_local_state()` would see `current_store` as
+                    // already matching its own address and treat the stale
+                    // cache as legitimately its own, without ever having
+                    // acquired it. Every subsequent `add_node`/`free_slot`
+                    // call for the new `Store` would then read/write this
+                    // thread's `LocalStoreState` under that false premise.
+                    local.current_store.set(0);
+                }
             }
         });
     }


### PR DESCRIPTION
I encountered a stack overflow with a particular usage pattern in my library petrivet, and Claude came up with this fix. I do not claim to understand this, but it looks important enough that I thought I would bring it to your attention @nhusung.

### Description

`LocalStoreStateGuard::drop()` only reset the thread-local `current_store` field (the address identifying which `Store` owns this thread's fast-path allocator cache) inside `drop_slow()`, which only runs when there is pending local state to flush back to the shared store. When a guard dropped with nothing to flush, `current_store` was left pointing at the `Store` that's being dropped.

If a later, different `Store` happened to be allocated at that exact freed address (plausible when same-sized arenas are created and dropped in sequence on the same thread, e.g. an application that builds and discards several decision diagram managers over its lifetime), that new `Store`'s `prepare_local_state()` would see `current_store` already matching its own address and treat the stale cache as legitimately its own, without ever having acquired it. Every subsequent `add_node`/`free_slot` call for the new `Store` would then read/write this thread's `LocalStoreState` under that false premise.

Reproduced via petrivet (github.com/MichaelOwenDyer/petrivet): building and dropping one `MTBDD` manager, then building a second one of similar capacity in the same process/thread, reliably produced a stack overflow deep inside `apply_bin`/`apply_ite` recursion on the second manager -- a recursion depth that should be structurally impossible
given the small number of variables involved, once the address-reuse hazard is understood as the cause. Confirmed empirically: reproduction requires (a) a first `Store` with a large enough arena that address reuse is likely, and (b) that first `Store` having actually allocated nodes (an empty, freshly-created-and-dropped `Store` does not trigger it, matching the fact that a fully "clean" `LocalStoreState` is a precondition for this bug). Verified the fix eliminates the crash at well beyond the original failure scale.